### PR TITLE
Fix ai prompt formatting and display

### DIFF
--- a/css/components/ai-prompt.css
+++ b/css/components/ai-prompt.css
@@ -33,6 +33,13 @@
   margin: 0;
 }
 
+.ai-prompt__text strong {
+  font-weight: 600;
+  font-style: normal;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 1.1em;
+}
+
 .ai-prompt__text::before {
   content: '"';
   font-size: 1.5em;

--- a/js/app.js
+++ b/js/app.js
@@ -341,7 +341,9 @@ const displayAIPrompt = async () => {
     const prompt = await window.AI.generateIntrospectionPrompt(state.character, state.entries);
     
     if (prompt) {
-      promptText.textContent = prompt;
+      // Format the prompt for proper display
+      const formattedPrompt = formatAIPrompt(prompt);
+      promptText.innerHTML = formattedPrompt;
       promptText.classList.remove('loading');
     } else {
       promptSection.style.display = 'none';
@@ -350,6 +352,27 @@ const displayAIPrompt = async () => {
     console.error('Failed to generate AI prompt:', error);
     promptSection.style.display = 'none';
   }
+};
+
+// Format AI prompt text for display
+const formatAIPrompt = (prompt) => {
+  if (!prompt) return '';
+  
+  // Convert markdown-like formatting to HTML
+  let formatted = prompt
+    // Convert **bold text** to <strong>
+    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+    // Convert line breaks to <br>
+    .replace(/\n/g, '<br>')
+    // Format numbered lists with proper spacing (add break before if not already there)
+    .replace(/<br>(\d+\.\s)/g, '<br><br>$1')
+    // Add extra spacing after section headers (but avoid triple breaks)
+    .replace(/(<strong>.*?<\/strong>)<br><br><br>/g, '$1<br><br>')
+    .replace(/(<strong>.*?<\/strong>)<br>(?!<br>)/g, '$1<br><br>')
+    // Clean up extra breaks at the beginning
+    .replace(/^<br>+/, '');
+  
+  return formatted;
 };
 
 // Setup event handlers for journal entries
@@ -424,5 +447,6 @@ if (typeof global !== 'undefined') {
   global.createCharacterSummary = createCharacterSummary;
   global.displayCharacterSummary = displayCharacterSummary;
   global.displayAIPrompt = displayAIPrompt;
+  global.formatAIPrompt = formatAIPrompt;
   global.init = init;
 }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -652,4 +652,44 @@ describe('D&D Journal App', function() {
       promptSection.style.display.should.equal('none');
     });
   });
+
+  describe('formatAIPrompt', function() {
+         it('should format bold text correctly', function() {
+       const input = '**Core Narrative Questions (1-3):**\n1. Test question';
+       const expected = '<strong>Core Narrative Questions (1-3):</strong><br><br>1. Test question';
+       
+       const result = formatAIPrompt(input);
+       result.should.equal(expected);
+     });
+
+    it('should convert line breaks correctly', function() {
+      const input = 'Question 1\nQuestion 2\nQuestion 3';
+      const expected = 'Question 1<br>Question 2<br>Question 3';
+      
+      const result = formatAIPrompt(input);
+      result.should.equal(expected);
+    });
+
+         it('should format numbered lists with proper spacing', function() {
+       const input = '1. First question\n2. Second question';
+       const expected = '1. First question<br><br>2. Second question';
+       
+       const result = formatAIPrompt(input);
+       result.should.equal(expected);
+     });
+
+    it('should handle empty or null input', function() {
+      formatAIPrompt('').should.equal('');
+      formatAIPrompt(null).should.equal('');
+      formatAIPrompt(undefined).should.equal('');
+    });
+
+         it('should format complete AI prompt correctly', function() {
+       const input = '**Core Narrative Questions (1-3):**\n1. Puoskari, can you share a pivotal memory?\n2. What current internal conflict?\n\n**The Third Choice (4):**\nA surprising question';
+       const expected = '<strong>Core Narrative Questions (1-3):</strong><br><br>1. Puoskari, can you share a pivotal memory?<br><br>2. What current internal conflict?<br><br><strong>The Third Choice (4):</strong><br><br>A surprising question';
+       
+       const result = formatAIPrompt(input);
+       result.should.equal(expected);
+     });
+  });
 });


### PR DESCRIPTION
Fix AI prompt formatting to display line breaks and bold text correctly.

The AI prompt was previously rendered using `textContent`, which stripped all formatting (like line breaks and bolding) from the markdown-like input. This made the prompt appear as a single block of unreadable text. This PR introduces a new formatting function that converts markdown elements (e.g., `**text**` to `<strong>text</strong>`, `\n` to `<br>`) and uses `innerHTML` to render the formatted content, ensuring the prompt is legible and structured as intended.

---

[Open in Web](https://www.cursor.com/agents?id=bc-8d349382-5ce8-44f8-b199-b100ca4433f3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8d349382-5ce8-44f8-b199-b100ca4433f3)