### PR TITLE
Investigate sync failures and test button errors

### DIFF
--- a/character.html
+++ b/character.html
@@ -22,9 +22,9 @@
     <link rel="stylesheet" href="css/components/character-form.css">
     
     <!-- Yjs Sync Enhancement (ADR-0003) - Optional libraries for cross-device sync -->
-    <script src="https://unpkg.com/yjs@13.6.10/dist/yjs.js"></script>
-    <script src="https://unpkg.com/y-websocket@1.5.4/dist/y-websocket.js"></script>
-    <script src="https://unpkg.com/y-indexeddb@9.0.12/dist/y-indexeddb.js"></script>
+    <script src="https://unpkg.com/yjs@13/dist/yjs.js"></script>
+    <script src="https://unpkg.com/y-websocket@3/dist/y-websocket.js"></script>
+    <script src="https://unpkg.com/y-indexeddb@9/dist/y-indexeddb.js"></script>
 </head>
 <body>
     <header>

--- a/index.html
+++ b/index.html
@@ -22,9 +22,9 @@
     <link rel="stylesheet" href="css/components/ai-prompt.css">
     
     <!-- Yjs Sync Enhancement (ADR-0003) - Optional libraries for cross-device sync -->
-    <script src="https://unpkg.com/yjs@13.6.10/dist/yjs.js"></script>
-    <script src="https://unpkg.com/y-websocket@1.5.4/dist/y-websocket.js"></script>
-    <script src="https://unpkg.com/y-indexeddb@9.0.12/dist/y-indexeddb.js"></script>
+    <script src="https://unpkg.com/yjs@13/dist/yjs.js"></script>
+    <script src="https://unpkg.com/y-websocket@3/dist/y-websocket.js"></script>
+    <script src="https://unpkg.com/y-indexeddb@9/dist/y-indexeddb.js"></script>
 </head>
 <body>
     <header>

--- a/settings.html
+++ b/settings.html
@@ -23,9 +23,9 @@
     <link rel="stylesheet" href="css/components/sync-status.css">
     
     <!-- Yjs Sync Enhancement - Optional libraries for cross-device sync -->
-    <script src="https://unpkg.com/yjs@13.6.10/dist/yjs.js"></script>
-    <script src="https://unpkg.com/y-websocket@1.5.4/dist/y-websocket.js"></script>
-    <script src="https://unpkg.com/y-indexeddb@9.0.12/dist/y-indexeddb.js"></script>
+    <script src="https://unpkg.com/yjs@13/dist/yjs.js"></script>
+    <script src="https://unpkg.com/y-websocket@3/dist/y-websocket.js"></script>
+    <script src="https://unpkg.com/y-indexeddb@9/dist/y-indexeddb.js"></script>
 </head>
 <body>
     <header>


### PR DESCRIPTION
Update Yjs library CDN URLs to resolve 404 errors and enable sync functionality.

The previous CDN URLs for Yjs, y-websocket, and y-indexeddb were pointing to outdated or non-existent patch versions (e.g., `yjs@13.6.10` and `y-websocket@1.5.4`), resulting in 404 errors. This prevented the sync libraries from loading, causing sync to be unavailable and the test button to incorrectly report missing libraries. This PR updates the URLs to use the latest major versions, ensuring the libraries load correctly.

---

[Open in Web](https://cursor.com/agents?id=bc-a3178de3-31ae-4544-a1b5-9a5a6d197aba) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a3178de3-31ae-4544-a1b5-9a5a6d197aba)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)