### PR TITLE
Update ai model to gpt-4.1 mini

### DIFF
--- a/js/ai.js
+++ b/js/ai.js
@@ -171,7 +171,7 @@ export const callOpenAI = async (prompt, maxTokens = 400) => {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4.1-mini',
         messages: [
           {
             role: 'system',


### PR DESCRIPTION
Switch the AI model from `gpt-3.5-turbo` to `gpt-4.1-mini` to leverage its improved performance and capabilities.

---

[Open in Web](https://cursor.com/agents?id=bc-6b7ba009-d3c5-4a27-ac1d-721bfa714e10) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6b7ba009-d3c5-4a27-ac1d-721bfa714e10)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)