### PR TITLE
Remove summary stats and fix remove button

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -7,7 +7,6 @@ import {
   safeSetToStorage, 
   STORAGE_KEYS 
 } from './utils.js';
-import { getSummaryStats, autoSummarizeEntries } from './summarization.js';
 import { clearAll } from './summarization.js';
 import { 
   getIntrospectionPromptForPreview,
@@ -133,9 +132,6 @@ const handleSettingsChange = () => {
   if (showPromptButton) {
     showPromptButton.disabled = !isAIEnabled();
   }
-  
-  // Update summary stats display
-  updateSummaryStats();
 };
 
 // Setup event handlers
@@ -156,11 +152,6 @@ const setupEventHandlers = () => {
     testButton.addEventListener('click', handleApiKeyTest);
   }
 
-  const generateSummariesButton = document.getElementById('generate-summaries');
-  if (generateSummariesButton) {
-    generateSummariesButton.addEventListener('click', handleGenerateSummaries);
-  }
-  
   const clearSummariesButton = document.getElementById('clear-summaries');
   if (clearSummariesButton) {
     clearSummariesButton.addEventListener('click', handleClearSummaries);
@@ -191,93 +182,9 @@ const setupEventHandlers = () => {
   }
 };
 
-// Update summary stats display
-const updateSummaryStats = () => {
-  const settings = loadSettings();
-  const summaryStatsDiv = document.getElementById('summary-stats');
-  
-  if (!summaryStatsDiv) return;
-  
-  if (!settings.enableAIFeatures || !settings.apiKey) {
-    summaryStatsDiv.style.display = 'none';
-    return;
-  }
-  
-  summaryStatsDiv.style.display = 'block';
-  
-  // Use the summarization module
-  try {
-    const stats = getSummaryStats();
-    
-    const totalEntriesEl = document.getElementById('total-entries');
-    const recentEntriesEl = document.getElementById('recent-entries');
-    const summarizedEntriesEl = document.getElementById('summarized-entries');
-    const pendingSummariesEl = document.getElementById('pending-summaries');
-    const progressFill = document.getElementById('summary-progress');
-    
-    // Meta-summary elements
-    const metaSummaryStatEl = document.getElementById('meta-summary-stat');
-    const metaSummariesEl = document.getElementById('meta-summaries');
-    const metaEntriesStatEl = document.getElementById('meta-entries-stat');
-    const metaEntriesEl = document.getElementById('meta-entries');
-    
-    if (totalEntriesEl) totalEntriesEl.textContent = stats.totalEntries;
-    if (recentEntriesEl) recentEntriesEl.textContent = stats.recentEntries;
-    if (summarizedEntriesEl) summarizedEntriesEl.textContent = stats.summarizedEntries;
-    if (pendingSummariesEl) pendingSummariesEl.textContent = stats.pendingSummaries;
-    
-    if (progressFill) {
-      progressFill.style.width = `${stats.summaryCompletionRate}%`;
-    }
-    
-    // Show meta-summary stats if meta-summarization is active
-    if (stats.metaSummaryActive) {
-      if (metaSummaryStatEl) metaSummaryStatEl.style.display = 'flex';
-      if (metaEntriesStatEl) metaEntriesStatEl.style.display = 'flex';
-      if (metaSummariesEl) metaSummariesEl.textContent = stats.metaSummaries;
-      if (metaEntriesEl) metaEntriesEl.textContent = stats.entriesInMetaSummaries;
-    } else {
-      if (metaSummaryStatEl) metaSummaryStatEl.style.display = 'none';
-      if (metaEntriesStatEl) metaEntriesStatEl.style.display = 'none';
-    }
-    
-    // Enable/disable clear summaries button based on whether there are summaries to clear
-    const clearSummariesButton = document.getElementById('clear-summaries');
-    if (clearSummariesButton) {
-      const hasSummaries = stats.totalSummaries > 0;
-      clearSummariesButton.disabled = !hasSummaries;
-    }
-  } catch (error) {
-    console.error('Failed to load summary stats:', error);
-    // Hide stats on error
-    summaryStatsDiv.style.display = 'none';
-  }
-};
 
-// Handle generate summaries button
-const handleGenerateSummaries = async () => {
-  const button = document.getElementById('generate-summaries');
-  if (!button) return;
-  
-  const originalText = button.textContent;
-  button.textContent = 'Generating...';
-  button.disabled = true;
-  
-  try {
-    const result = await autoSummarizeEntries();
-    if (result && result.length > 0) {
-      alert(`Generated ${result.length} summaries.`);
-      updateSummaryStats();
-    } else {
-      alert('No summaries needed at this time.');
-    }
-  } catch (error) {
-    alert('Failed to generate summaries: ' + error.message);
-  } finally {
-    button.textContent = originalText;
-    button.disabled = false;
-  }
-};
+
+
 
 // Handle clear summaries button
 const handleClearSummaries = async () => {
@@ -297,7 +204,6 @@ const handleClearSummaries = async () => {
     const result = clearAll();
     if (result) {
       alert('All summaries have been cleared successfully.');
-      updateSummaryStats();
     } else {
       alert('Failed to clear summaries.');
     }
@@ -515,7 +421,6 @@ const populateForm = () => {
     } catch (e) {}
   }
   
-  updateSummaryStats();
   updateSimpleSyncStatus();
 };
 

--- a/settings.html
+++ b/settings.html
@@ -129,47 +129,13 @@
                         </div>
                     </div>
                     
-                    <div class="form-group" id="summary-stats" style="display: none;">
-                        <div class="summary-stats">
-                            <h3>Entry Summarization Status</h3>
-                            <div class="stats-grid">
-                                <div class="stat-item">
-                                    <span class="stat-label">Total Entries:</span>
-                                    <span class="stat-value" id="total-entries">0</span>
-                                </div>
-                                <div class="stat-item">
-                                    <span class="stat-label">Recent (Full):</span>
-                                    <span class="stat-value" id="recent-entries">0</span>
-                                </div>
-                                <div class="stat-item">
-                                    <span class="stat-label">Summarized:</span>
-                                    <span class="stat-value" id="summarized-entries">0</span>
-                                </div>
-                                <div class="stat-item">
-                                    <span class="stat-label">Pending:</span>
-                                    <span class="stat-value" id="pending-summaries">0</span>
-                                </div>
-                                <div class="stat-item" id="meta-summary-stat" style="display: none;">
-                                    <span class="stat-label">Meta-Summaries:</span>
-                                    <span class="stat-value" id="meta-summaries">0</span>
-                                </div>
-                                <div class="stat-item" id="meta-entries-stat" style="display: none;">
-                                    <span class="stat-label">In Meta-Summaries:</span>
-                                    <span class="stat-value" id="meta-entries">0</span>
-                                </div>
-                            </div>
-                            <div class="progress-bar">
-                                <div class="progress-fill" id="summary-progress"></div>
-                            </div>
-                            <div class="summary-actions">
-                                <button id="generate-summaries" class="btn btn-secondary">
-                                    Generate Missing Summaries
-                                </button>
-                                <button id="clear-summaries" class="btn btn-danger">
-                                    Clear All Summaries
-                                </button>
-                            </div>
-                        </div>
+                    <div class="form-group">
+                        <button id="clear-summaries" class="btn btn-danger">
+                            Clear All Summaries
+                        </button>
+                        <p class="form-help">
+                            Remove all generated summaries from storage. This action cannot be undone.
+                        </p>
                     </div>
                 </section>
             </div>


### PR DESCRIPTION
Remove summary statistics and the generate summaries button from settings, and re-enable the clear summaries button.

The clear summaries button was previously broken due to its dependency on the now-removed summary statistics display and generation logic, which also caused it to be conditionally disabled. Removing these dependencies ensures it is always enabled and functional as requested.

---

[Open in Web](https://cursor.com/agents?id=bc-ebd0b157-ec17-45fa-9b3e-92c1bf774147) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ebd0b157-ec17-45fa-9b3e-92c1bf774147) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)