### PR TITLE
Add settings save buttons and improve sync check

### DIFF
--- a/css/components/settings.css
+++ b/css/components/settings.css
@@ -204,3 +204,44 @@
   border-color: #6c757d;
   cursor: not-allowed;
 }
+
+/* Save button styles */
+.btn-primary:disabled {
+  background: #6c757d;
+  border-color: #6c757d;
+  color: white;
+  cursor: not-allowed;
+}
+
+/* Success state for save buttons */
+.btn.btn-success {
+  background: #28a745;
+  border-color: #28a745;
+  color: white;
+}
+
+/* Settings section separation */
+.settings-section-actions {
+  margin-top: var(--space-lg);
+  padding-top: var(--space-md);
+  border-top: var(--border-width) solid var(--color-border-light);
+}
+
+/* Test result styles for sync */
+.test-success {
+  color: #155724;
+  background-color: #d4edda;
+  border: 1px solid #c3e6cb;
+  padding: var(--space-sm);
+  border-radius: var(--border-radius);
+  margin-top: var(--space-sm);
+}
+
+.test-error {
+  color: #721c24;
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  padding: var(--space-sm);
+  border-radius: var(--border-radius);
+  margin-top: var(--space-sm);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "y-indexeddb": "^9.0.12",
-        "y-websocket": "^1.5.4",
         "yjs": "^13.6.27"
       },
       "devDependencies": {

--- a/settings.html
+++ b/settings.html
@@ -56,6 +56,9 @@
                             id="sync-server" 
                             class="form-input" 
                             placeholder="wss://your-server.com:1234 or ws://192.168.1.100:1234"
+                            autocomplete="off"
+                            data-lpignore="true"
+                            data-1p-ignore="true"
                         >
                         <p class="form-help">
                             Leave empty to use default public servers. Enter a WebSocket URL to use your own server.
@@ -81,6 +84,12 @@
                         </div>
                         <p class="form-help" id="sync-help">Device syncing status will appear here.</p>
                     </div>
+                    
+                    <div class="form-group settings-section-actions">
+                        <button id="save-sync-settings" class="btn btn-primary">
+                            Save Sync Settings
+                        </button>
+                    </div>
                 </section>
 
                 <section>
@@ -95,6 +104,8 @@
                             class="form-input" 
                             placeholder="sk-..."
                             autocomplete="off"
+                            data-lpignore="true"
+                            data-1p-ignore="true"
                         >
                         <p class="form-help">
                             Your API key is stored locally and never sent to our servers.
@@ -133,6 +144,12 @@
                         <p class="form-help">
                             Remove all generated summaries from storage. This action cannot be undone.
                         </p>
+                    </div>
+                    
+                    <div class="form-group settings-section-actions">
+                        <button id="save-ai-settings" class="btn btn-primary">
+                            Save AI Settings
+                        </button>
                     </div>
                 </section>
             </div>


### PR DESCRIPTION
Add explicit save buttons to settings and improve sync server validation.

This addresses Bitwarden autofill interference by replacing auto-save with explicit saves, and ensures the sync check fails gracefully for invalid server URLs, such as email addresses.

---

[Open in Web](https://cursor.com/agents?id=bc-063ed6c6-3ec5-486e-806c-259f998490d7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-063ed6c6-3ec5-486e-806c-259f998490d7) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)