### PR TITLE
Adjust workflow script indentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,30 +13,30 @@ jobs:
         node-version: [22.x]
     
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+      - name: Checkout code
+        uses: actions/checkout@v4
         
-    - name: Install dependencies
-      run: npm ci
-      
-    - name: Run tests
-      run: npm test
-      env:
-        NODE_ENV: test
-      
-    - name: Validate static files
-      run: npm run validate
-      
-    - name: Deploy to Surge
-      run: |
-        npm install -g surge
-        surge . --domain dnd-journal.surge.sh
-      env:
-        SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
-        SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Run tests
+        run: npm test
+        env:
+          NODE_ENV: test
+        
+      - name: Validate static files
+        run: npm run validate
+        
+      - name: Deploy to Surge
+        run: |
+          npm install -g surge
+          surge . --domain dnd-journal.surge.sh
+        env:
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Corrected indentation for workflow steps in `deploy.yml` to align with GitHub Actions YAML standards.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `deploy.yml` file had its `steps` indented with only 4 spaces, while the standard for GitHub Actions YAML requires 6 spaces for step items under the `steps:` section. This PR adjusts the indentation to the correct 6 spaces for consistency and adherence to best practices.

---

[Open in Web](https://cursor.com/agents?id=bc-a690274a-83f4-4063-996b-3eadcf4a9d22) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a690274a-83f4-4063-996b-3eadcf4a9d22) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)