### PR TITLE
Add github action for surge deployment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,6 +23,32 @@
 - **ADR-0006**: No build tools (uses npm scripts only)
 - **ADR-0013**: Radical simplicity (minimal, focused workflow)
 
+## Deploy to Surge (`deploy.yml`)
+
+**Purpose**: Automated deployment to Surge.sh on main branch updates.
+
+**Triggers**:
+- Pushes to `main` branch only
+
+**What it does**:
+1. ✅ Runs tests to ensure code quality
+2. 🚀 Deploys static files to dnd-journal.surge.sh
+3. 📝 Uses existing npm deploy script
+
+**Commands used**:
+- `npm ci` - Install dependencies
+- `npm test` - Run test suite (ensures quality before deploy)
+- `npm run deploy` - Deploy to Surge.sh
+
+**Required Secrets**:
+- `SURGE_LOGIN` - Surge.sh account email
+- `SURGE_TOKEN` - Surge.sh authentication token
+
+**Compliance**:
+- **ADR-0008**: Surge.sh deployment only
+- **ADR-0006**: No build tools (direct static file deployment)
+- **ADR-0013**: Radical simplicity (minimal deployment workflow)
+
 ---
 
-*This workflow ensures all code changes are tested before merging, maintaining code quality without complexity.*
+*These workflows ensure all code changes are tested before merging and automatically deployed to production, maintaining code quality and deployment simplicity.*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to Surge
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+          cache: npm
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Run tests
+        run: npm test
+      
+      - name: Deploy to Surge
+        run: npm run deploy
+        env:
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
Add GitHub Action to automate deployment to Surge.sh, ensuring compliance with project ADRs for static site deployment and radical simplicity.

---

[Open in Web](https://cursor.com/agents?id=bc-65e1847f-2263-44a7-a4f7-df1e38a1d8fb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-65e1847f-2263-44a7-a4f7-df1e38a1d8fb) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)