### PR TITLE
Fix unnamed characters on journal pages

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -461,7 +461,7 @@ export const createCharacterSummary = (character) => {
 
 // Create simplified character data for main page display
 export const createSimpleCharacterData = (character) => {
-  if (!character || !character.name) {
+  if (!character) {
     return {
       name: 'Unnamed Character',
       race: 'Unknown',
@@ -469,8 +469,13 @@ export const createSimpleCharacterData = (character) => {
     };
   }
   
+  // Determine the display name - use 'Unnamed Character' if name is missing or just whitespace
+  const displayName = (!character.name || character.name.trim() === '') 
+    ? 'Unnamed Character' 
+    : character.name.trim();
+  
   return {
-    name: character.name,
+    name: displayName,
     race: character.race || 'Unknown',
     class: character.class || 'Unknown'
   };

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -348,6 +348,35 @@ describe('D&D Journal App', function() {
       expect(result.race).to.equal('Unknown');
       expect(result.class).to.equal('Unknown');
     });
+
+    it('should handle character with whitespace-only name', function() {
+      const character = {
+        name: '   ', // Only whitespace
+        race: 'Elf',
+        class: 'Ranger',
+        backstory: 'A character with whitespace name'
+      };
+      
+      const result = App.createSimpleCharacterData(character);
+      
+      expect(result.name).to.equal('Unnamed Character');
+      expect(result.race).to.equal('Elf');
+      expect(result.class).to.equal('Ranger');
+    });
+
+    it('should trim character name with leading/trailing whitespace', function() {
+      const character = {
+        name: '  Legolas  ', // Name with whitespace
+        race: 'Elf',
+        class: 'Ranger'
+      };
+      
+      const result = App.createSimpleCharacterData(character);
+      
+      expect(result.name).to.equal('Legolas');
+      expect(result.race).to.equal('Elf');
+      expect(result.class).to.equal('Ranger');
+    });
   });
 
   describe('Display Character Summary', function() {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -276,4 +276,134 @@ describe('D&D Journal Integration Tests', function() {
       expect(App.state.entries[0].content).to.equal('Updated content');
     }
   });
+
+  // Note: Test for character name display functionality is covered by unit tests
+  // in app.test.js "Display Character Summary" section and "Simple Character Data" section
+
+  it('should handle character data persistence across page navigation simulation', function() {
+    // This test simulates navigating from character page to journal page
+    
+    // Set up DOM elements for journal page
+    const nameEl = document.createElement('span');
+    nameEl.id = 'display-name';
+    const raceEl = document.createElement('span');
+    raceEl.id = 'display-race';
+    const classEl = document.createElement('span');
+    classEl.id = 'display-class';
+    
+    document.body.appendChild(nameEl);
+    document.body.appendChild(raceEl);
+    document.body.appendChild(classEl);
+
+    // Simulate character page workflow
+    // 1. Load existing data (empty initially)
+    App.loadData();
+    
+    // 2. User enters character information
+    const characterData = {
+      name: 'Gimli',
+      race: 'Dwarf',
+      class: 'Fighter',
+      backstory: 'Son of Glóin',
+      notes: 'Wields an ancestral axe'
+    };
+    
+    // 3. Character page saves the data
+    App.state.character = characterData;
+    App.saveData();
+
+    // Simulate page navigation - reset app state and reload from localStorage
+    App.resetState();
+    App.loadData();
+
+    // Verify character data is properly loaded
+    expect(App.state.character.name).to.equal('Gimli');
+    expect(App.state.character.race).to.equal('Dwarf');
+    expect(App.state.character.class).to.equal('Fighter');
+
+    // Display character summary on journal page
+    App.displayCharacterSummary();
+
+    // Verify the display shows the correct character name (not "Unnamed Character")
+    expect(document.getElementById('display-name').textContent).to.equal('Gimli');
+    expect(document.getElementById('display-race').textContent).to.equal('Dwarf');
+    expect(document.getElementById('display-class').textContent).to.equal('Fighter');
+
+    // Clean up DOM elements
+    nameEl.remove();
+    raceEl.remove();
+    classEl.remove();
+  });
+
+  it('should show "Unnamed Character" when character name is empty string', function() {
+    // Set up DOM elements for journal page
+    const nameEl = document.createElement('span');
+    nameEl.id = 'display-name';
+    const raceEl = document.createElement('span');
+    raceEl.id = 'display-race';
+    const classEl = document.createElement('span');
+    classEl.id = 'display-class';
+    
+    document.body.appendChild(nameEl);
+    document.body.appendChild(raceEl);
+    document.body.appendChild(classEl);
+
+    // Set character data with empty name (simulating partially filled character form)
+    App.state.character = {
+      name: '', // Empty string name
+      race: 'Elf',
+      class: 'Ranger',
+      backstory: 'A mysterious character',
+      notes: 'Has filled out other fields but not name'
+    };
+
+    // Display character summary
+    App.displayCharacterSummary();
+
+    // Should show "Unnamed Character" because name is empty
+    expect(document.getElementById('display-name').textContent).to.equal('Unnamed Character');
+    expect(document.getElementById('display-race').textContent).to.equal('Elf');
+    expect(document.getElementById('display-class').textContent).to.equal('Ranger');
+
+    // Clean up DOM elements
+    nameEl.remove();
+    raceEl.remove();
+    classEl.remove();
+  });
+
+  it('should properly handle character data when name is whitespace only', function() {
+    // Set up DOM elements for journal page
+    const nameEl = document.createElement('span');
+    nameEl.id = 'display-name';
+    const raceEl = document.createElement('span');
+    raceEl.id = 'display-race';
+    const classEl = document.createElement('span');
+    classEl.id = 'display-class';
+    
+    document.body.appendChild(nameEl);
+    document.body.appendChild(raceEl);
+    document.body.appendChild(classEl);
+
+    // Test character with name that is only whitespace (common user input error)
+    App.state.character = {
+      name: '   ', // Only whitespace
+      race: 'Elf',
+      class: 'Ranger',
+      backstory: 'A character with whitespace name',
+      notes: 'User may have entered spaces accidentally'
+    };
+
+    // Display character summary
+    App.displayCharacterSummary();
+
+    // Should show "Unnamed Character" because whitespace-only name should be treated as empty
+    expect(document.getElementById('display-name').textContent).to.equal('Unnamed Character');
+    expect(document.getElementById('display-race').textContent).to.equal('Elf');
+    expect(document.getElementById('display-class').textContent).to.equal('Ranger');
+
+    // Clean up DOM elements
+    nameEl.remove();
+    raceEl.remove();
+    classEl.remove();
+  });
 });


### PR DESCRIPTION
Fixes journal page displaying unnamed characters when names are empty or whitespace-only, and trims displayed names.

The `createSimpleCharacterData` function was not correctly identifying names that were empty or contained only whitespace, leading to "Unnamed Character" not being displayed as intended. This PR updates the logic to properly trim and validate character names, ensuring the correct display while preserving other character details.

---

[Open in Web](https://cursor.com/agents?id=bc-03450eeb-3fcb-47df-9b3b-6b3968b0c7c5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-03450eeb-3fcb-47df-9b3b-6b3968b0c7c5) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)