### PR TITLE
Fix missing lib0 modules

### DIFF
--- a/character.html
+++ b/character.html
@@ -30,7 +30,28 @@
         "yjs": "./node_modules/yjs/dist/yjs.mjs",
         "y-websocket": "./node_modules/y-websocket/src/y-websocket.js",
         "y-indexeddb": "./node_modules/y-indexeddb/src/y-indexeddb.js",
-        "lib0/": "./node_modules/lib0/"
+        "lib0/observable": "./node_modules/lib0/observable.js",
+        "lib0/array": "./node_modules/lib0/array.js",
+        "lib0/math": "./node_modules/lib0/math.js",
+        "lib0/map": "./node_modules/lib0/map.js",
+        "lib0/encoding": "./node_modules/lib0/encoding.js",
+        "lib0/decoding": "./node_modules/lib0/decoding.js",
+        "lib0/random": "./node_modules/lib0/random.js",
+        "lib0/promise": "./node_modules/lib0/promise.js",
+        "lib0/buffer": "./node_modules/lib0/buffer.js",
+        "lib0/error": "./node_modules/lib0/error.js",
+        "lib0/binary": "./node_modules/lib0/binary.js",
+        "lib0/function": "./node_modules/lib0/function.js",
+        "lib0/set": "./node_modules/lib0/set.js",
+        "lib0/logging": "./node_modules/lib0/logging.js",
+        "lib0/time": "./node_modules/lib0/time.js",
+        "lib0/string": "./node_modules/lib0/string.js",
+        "lib0/iterator": "./node_modules/lib0/iterator.js",
+        "lib0/object": "./node_modules/lib0/object.js",
+        "lib0/environment": "./node_modules/lib0/environment.js",
+        "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
+        "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
+        "lib0/url": "./node_modules/lib0/url.js"
       }
     }
     </script>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,28 @@
         "yjs": "./node_modules/yjs/dist/yjs.mjs",
         "y-websocket": "./node_modules/y-websocket/src/y-websocket.js",
         "y-indexeddb": "./node_modules/y-indexeddb/src/y-indexeddb.js",
-        "lib0/": "./node_modules/lib0/"
+        "lib0/observable": "./node_modules/lib0/observable.js",
+        "lib0/array": "./node_modules/lib0/array.js",
+        "lib0/math": "./node_modules/lib0/math.js",
+        "lib0/map": "./node_modules/lib0/map.js",
+        "lib0/encoding": "./node_modules/lib0/encoding.js",
+        "lib0/decoding": "./node_modules/lib0/decoding.js",
+        "lib0/random": "./node_modules/lib0/random.js",
+        "lib0/promise": "./node_modules/lib0/promise.js",
+        "lib0/buffer": "./node_modules/lib0/buffer.js",
+        "lib0/error": "./node_modules/lib0/error.js",
+        "lib0/binary": "./node_modules/lib0/binary.js",
+        "lib0/function": "./node_modules/lib0/function.js",
+        "lib0/set": "./node_modules/lib0/set.js",
+        "lib0/logging": "./node_modules/lib0/logging.js",
+        "lib0/time": "./node_modules/lib0/time.js",
+        "lib0/string": "./node_modules/lib0/string.js",
+        "lib0/iterator": "./node_modules/lib0/iterator.js",
+        "lib0/object": "./node_modules/lib0/object.js",
+        "lib0/environment": "./node_modules/lib0/environment.js",
+        "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
+        "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
+        "lib0/url": "./node_modules/lib0/url.js"
       }
     }
     </script>

--- a/settings.html
+++ b/settings.html
@@ -31,7 +31,28 @@
         "yjs": "./node_modules/yjs/dist/yjs.mjs",
         "y-websocket": "./node_modules/y-websocket/src/y-websocket.js",
         "y-indexeddb": "./node_modules/y-indexeddb/src/y-indexeddb.js",
-        "lib0/": "./node_modules/lib0/"
+        "lib0/observable": "./node_modules/lib0/observable.js",
+        "lib0/array": "./node_modules/lib0/array.js",
+        "lib0/math": "./node_modules/lib0/math.js",
+        "lib0/map": "./node_modules/lib0/map.js",
+        "lib0/encoding": "./node_modules/lib0/encoding.js",
+        "lib0/decoding": "./node_modules/lib0/decoding.js",
+        "lib0/random": "./node_modules/lib0/random.js",
+        "lib0/promise": "./node_modules/lib0/promise.js",
+        "lib0/buffer": "./node_modules/lib0/buffer.js",
+        "lib0/error": "./node_modules/lib0/error.js",
+        "lib0/binary": "./node_modules/lib0/binary.js",
+        "lib0/function": "./node_modules/lib0/function.js",
+        "lib0/set": "./node_modules/lib0/set.js",
+        "lib0/logging": "./node_modules/lib0/logging.js",
+        "lib0/time": "./node_modules/lib0/time.js",
+        "lib0/string": "./node_modules/lib0/string.js",
+        "lib0/iterator": "./node_modules/lib0/iterator.js",
+        "lib0/object": "./node_modules/lib0/object.js",
+        "lib0/environment": "./node_modules/lib0/environment.js",
+        "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
+        "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
+        "lib0/url": "./node_modules/lib0/url.js"
       }
     }
     </script>


### PR DESCRIPTION
Fix 404 errors for `lib0` modules by explicitly mapping each module with its `.js` extension in the import map.

The previous import map used a generic `"lib0/": "./node_modules/lib0/"` which did not correctly resolve individual `lib0` module imports (e.g., `lib0/observable`) that lacked the `.js` extension, leading to 404 errors. This change provides explicit mappings for all required `lib0` modules in `index.html`, `character.html`, and `settings.html`.

---

[Open in Web](https://cursor.com/agents%3Fid=bc-8cd52af7-b356-4729-a8fb-02ba4846f0a4) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-8cd52af7-b356-4729-a8fb-02ba4846f0a4) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)