### PR TITLE
Fix module specifier error in settings.html

### DIFF
--- a/character.html
+++ b/character.html
@@ -51,7 +51,8 @@
         "lib0/environment": "./node_modules/lib0/environment.js",
         "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
         "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
-        "lib0/url": "./node_modules/lib0/url.js"
+        "lib0/url": "./node_modules/lib0/url.js",
+        "lib0/webcrypto": "./node_modules/lib0/webcrypto.js"
       }
     }
     </script>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,8 @@
         "lib0/environment": "./node_modules/lib0/environment.js",
         "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
         "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
-        "lib0/url": "./node_modules/lib0/url.js"
+        "lib0/url": "./node_modules/lib0/url.js",
+        "lib0/webcrypto": "./node_modules/lib0/webcrypto.js"
       }
     }
     </script>

--- a/settings.html
+++ b/settings.html
@@ -52,7 +52,8 @@
         "lib0/environment": "./node_modules/lib0/environment.js",
         "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
         "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
-        "lib0/url": "./node_modules/lib0/url.js"
+        "lib0/url": "./node_modules/lib0/url.js",
+        "lib0/webcrypto": "./node_modules/lib0/webcrypto.js"
       }
     }
     </script>


### PR DESCRIPTION
Add `lib0/webcrypto` mapping to import maps in HTML files to resolve module resolution errors.

The `lib0` library, used by YJS for synchronization, internally imports `lib0/webcrypto`. Without this mapping in the import maps of `index.html`, `character.html`, and `settings.html`, the browser failed to resolve the module, leading to console errors and potential functionality issues.

---

[Open in Web](https://cursor.com/agents?id=bc-3600d2d5-b8a2-477e-8bb2-a0324e537309) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3600d2d5-b8a2-477e-8bb2-a0324e537309) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)