### PR TITLE
Prevent Bitwarden autofill in settings

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -80,7 +80,7 @@
         <div class="container">
             <a href="index.html" class="nav-back">← Back to Journal</a>
             
-            <div class="settings-container">
+            <div class="settings-container" data-bwignore="true">
                 <!-- Sync Configuration Section -->
                 <section class="settings-section">
                     <div class="settings-section-header">
@@ -104,6 +104,8 @@
                                 autocomplete="off"
                                 data-lpignore="true"
                                 data-1p-ignore="true"
+                                data-bwignore="true"
+                                data-form-type="other"
                             >
                             <p class="form-help">
                                 Leave empty to use public servers. Enter a WebSocket URL to use your own private server.
@@ -157,6 +159,8 @@
                                 autocomplete="off"
                                 data-lpignore="true"
                                 data-1p-ignore="true"
+                                data-bwignore="true"
+                                data-form-type="other"
                             >
                             <p class="form-help">
                                 Your API key is stored locally and never sent to our servers.


### PR DESCRIPTION
Add Bitwarden-specific attributes to settings fields to prevent unwanted autofill.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7021a8c-555d-4401-b7a7-a84f3d9af575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7021a8c-555d-4401-b7a7-a84f3d9af575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>