### PR TITLE
Fix undefined Y in test connection

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -1,6 +1,6 @@
 // Settings Page - AI Configuration & Data Management
 
-import { getSystem } from './yjs.js';
+import { getSystem, Y, WebsocketProvider } from './yjs.js';
 import { createInitialSettings, createInitialJournalState } from './utils.js';
 // testApiKey is defined in this module
 

--- a/js/yjs.js
+++ b/js/yjs.js
@@ -4,8 +4,8 @@ import { IndexeddbPersistence } from 'y-indexeddb';
 import { WebsocketProvider } from 'y-websocket';
 import { SYNC_CONFIG } from '../sync-config.js';
 
-// Export Y constructor for other modules
-export { Y };
+// Export Y constructor and WebsocketProvider for other modules
+export { Y, WebsocketProvider };
 
 // Yjs system instance
 let yjsSystem = null;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes "Y is not defined" error in the test connection button by adding missing Y.js imports and exports.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `js/settings.js` file was attempting to use `Y.Doc()` and `WebsocketProvider` without importing them, and `WebsocketProvider` was not exported from `js/yjs.js`, leading to a runtime error when the test connection button was clicked.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a4ef750-ec38-44a0-924c-6f2f702ed2a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a4ef750-ec38-44a0-924c-6f2f702ed2a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>