### PR TITLE
Remove yjs fallback servers

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -301,28 +301,11 @@ const handleShowAIPrompt = async () => {
 // Test sync server connection
 const testSyncServer = async (serverUrl) => {
 
-  // If no custom server URL, test default public servers
+  // If no custom server URL, return error - no fallback servers available
   if (!serverUrl) {
-    const defaultServers = [
-      'wss://demos.yjs.dev',
-      'wss://y-websocket.herokuapp.com'
-    ];
-    // Note: These are demo servers that may have limited reliability
-    
-    // Test the first available public server
-    for (const server of defaultServers) {
-      const result = await testSingleServer(server);
-      if (result.success) {
-        return { 
-          success: true, 
-          message: `Public sync server (${server}) is working!` 
-        };
-      }
-    }
-    
-    return { 
-      success: false, 
-      error: 'Unable to connect to public sync servers' 
+    return {
+      success: false,
+      message: 'No sync server configured. Please set up your own sync server or use localhost for development.'
     };
   }
   

--- a/js/yjs.js
+++ b/js/yjs.js
@@ -108,7 +108,8 @@ const getSyncServers = () => {
     console.warn('Error loading sync config:', e);
   }
   
-  return ['wss://demos.yjs.dev', 'wss://y-websocket.herokuapp.com'];
+  // No fallback servers - user must configure their own sync server
+  return [];
 };
 
 // Create sync providers


### PR DESCRIPTION
Remove public YJS fallback servers to eliminate reliability issues and improve user guidance.

The previous setup relied on unreliable public demo servers, leading to connection errors and a poor user experience. This change ensures that users either use local-first persistence or explicitly configure their own reliable sync servers, aligning with the application's design principles.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9df25fc-9f41-4f71-b09d-d71fd181705a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9df25fc-9f41-4f71-b09d-d71fd181705a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>