### PR TITLE
Fix ios PWA character and settings page recognition

### DIFF
--- a/character.html
+++ b/character.html
@@ -65,16 +65,16 @@
         <div class="tabs__container">
             <h1 class="tabs__title">D&D Journal</h1>
             <nav class="tabs__nav">
-                <a href="index.html" class="tabs__tab">Journal</a>
-                <a href="character.html" class="tabs__tab tabs__tab--active">Character</a>
-                <a href="settings.html" class="tabs__tab">Settings</a>
+                <a href="/" class="tabs__tab">Journal</a>
+                <a href="/character.html" class="tabs__tab tabs__tab--active">Character</a>
+                <a href="/settings.html" class="tabs__tab">Settings</a>
             </nav>
         </div>
     </header>
     
     <main>
         <div class="container">
-            <a href="index.html" class="nav-back">← Back to Journal</a>
+            <a href="/" class="nav-back">← Back to Journal</a>
             
             <div class="grid">
                 <!-- Basic Information -->

--- a/index.html
+++ b/index.html
@@ -68,9 +68,9 @@
         <div class="tabs__container">
             <h1 class="tabs__title">D&D Journal</h1>
             <nav class="tabs__nav">
-                <a href="index.html" class="tabs__tab tabs__tab--active">Journal</a>
-                <a href="character.html" class="tabs__tab">Character</a>
-                <a href="settings.html" class="tabs__tab">Settings</a>
+                <a href="/" class="tabs__tab tabs__tab--active">Journal</a>
+                <a href="/character.html" class="tabs__tab">Character</a>
+                <a href="/settings.html" class="tabs__tab">Settings</a>
             </nav>
             <div class="sync-status" id="sync-status" style="display: none;">
                 <span class="sync-indicator">

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,13 @@
 {
   "name": "D&D Journal",
   "short_name": "D&D Journal",
+  "id": "/",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#2c3e50",
+  "handle_links": "preferred",
   "icons": [
     {
       "src": "favicon.svg",

--- a/settings.html
+++ b/settings.html
@@ -69,16 +69,16 @@
         <div class="tabs__container">
             <h1 class="tabs__title">D&D Journal</h1>
             <nav class="tabs__nav">
-                <a href="index.html" class="tabs__tab">Journal</a>
-                <a href="character.html" class="tabs__tab">Character</a>
-                <a href="settings.html" class="tabs__tab tabs__tab--active">Settings</a>
+                <a href="/" class="tabs__tab">Journal</a>
+                <a href="/character.html" class="tabs__tab">Character</a>
+                <a href="/settings.html" class="tabs__tab tabs__tab--active">Settings</a>
             </nav>
         </div>
     </header>
     
     <main>
         <div class="container">
-            <a href="index.html" class="nav-back">← Back to Journal</a>
+            <a href="/" class="nav-back">← Back to Journal</a>
             
             <div class="settings-container" data-bwignore="true">
                 <!-- Sync Configuration Section -->


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix iOS PWA navigation by updating manifest scope and using absolute paths for internal links.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
iOS PWAs are strict about scope handling. Links that don't match the defined scope or use relative paths not recognized as internal navigation are treated as external, causing the "Done" button to appear. This fix explicitly defines the PWA scope in `manifest.json` and updates all internal navigation links to use absolute paths, ensuring iOS recognizes them as part of the standalone app.

---
<a href="https://cursor.com/background-agent?bcId=bc-0601bff6-dbf3-4704-a3d8-fe886b024646">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0601bff6-dbf3-4704-a3d8-fe886b024646">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>