### PR TITLE
Fix empty journal page display

### DIFF
--- a/js/journal-views.js
+++ b/js/journal-views.js
@@ -170,6 +170,12 @@ export const renderCharacterSummary = (container, character) => {
   
   container.innerHTML = '';
   
+  // Defensive check for character object
+  if (!character || typeof character !== 'object') {
+    container.appendChild(createEmptyState('No character information yet.'));
+    return;
+  }
+  
   if (!character.name && !character.race && !character.class) {
     container.appendChild(createEmptyState('No character information yet.'));
     return;
@@ -186,7 +192,7 @@ export const renderCharacterSummary = (container, character) => {
   
   fields.forEach(field => {
     const value = character[field.key];
-    if (value) {
+    if (value && value.trim && value.trim()) {
       const fieldDiv = document.createElement('div');
       fieldDiv.className = 'character-field';
       
@@ -211,7 +217,8 @@ export const renderEntries = (container, entries, options = {}) => {
   
   container.innerHTML = '';
   
-  if (entries.length === 0) {
+  // Defensive check for entries array
+  if (!entries || !Array.isArray(entries) || entries.length === 0) {
     container.appendChild(createEmptyState('No journal entries yet. Start writing your adventure!'));
     return;
   }
@@ -219,8 +226,10 @@ export const renderEntries = (container, entries, options = {}) => {
   const sortedEntries = sortEntriesByDate(entries);
   
   sortedEntries.forEach(entry => {
-    const entryElement = createEntryElement(entry, options.onEdit, options.onDelete);
-    container.appendChild(entryElement);
+    if (entry && entry.id) {
+      const entryElement = createEntryElement(entry, options.onEdit, options.onDelete);
+      container.appendChild(entryElement);
+    }
   });
 };
 

--- a/js/journal.js
+++ b/js/journal.js
@@ -29,7 +29,7 @@ let entryFormContainer = null;
 // Initialize Journal page
 export const initJournalPage = async (stateParam = null) => {
   try {
-    const state = stateParam || (await initYjs(), getYjsState());
+    const state = stateParam || await initYjs();
     
     // Get DOM elements
     entriesContainer = document.getElementById('entries-container');
@@ -41,10 +41,7 @@ export const initJournalPage = async (stateParam = null) => {
       return;
     }
     
-    // Render initial state
-    renderJournalPage(state);
-    
-    // Set up reactive updates
+    // Set up reactive updates first
     onJournalChange(state, () => {
       renderJournalPage(state);
     });
@@ -55,6 +52,14 @@ export const initJournalPage = async (stateParam = null) => {
     
     // Set up form
     setupEntryForm();
+    
+    // Render initial state immediately
+    renderJournalPage(state);
+    
+    // Also render again after a delay to catch any data that loads asynchronously
+    setTimeout(() => {
+      renderJournalPage(state);
+    }, 100);
     
   } catch (error) {
     console.error('Failed to initialize journal page:', error);
@@ -228,7 +233,9 @@ const clearEntryForm = () => {
   }
 };
 
-// Initialize the journal page when the script loads
-document.addEventListener('DOMContentLoaded', () => {
-  initJournalPage();
-});
+// Initialize the journal page when the script loads (only in browser)
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    initJournalPage();
+  });
+}

--- a/js/yjs.js
+++ b/js/yjs.js
@@ -32,14 +32,14 @@ export const initYjs = async () => {
   // Set up persistence
   const persistence = new IndexeddbPersistence('dnd-journal', ydoc);
   
-  // Mark as initialized first, then set up sync
+  // Mark as initialized
   isInitialized = true;
+  
+  // Wait for IndexedDB to load existing data
+  await new Promise(resolve => setTimeout(resolve, 200));
   
   // Set up sync server from settings (if configured)
   setupSyncFromSettings();
-  
-  // Wait for initial sync
-  await new Promise(resolve => setTimeout(resolve, 100));
   
   return getYjsState();
 };


### PR DESCRIPTION
Fix journal page not displaying data by improving Y.js initialization, rendering logic, and adding defensive data checks.

The journal page failed to display data due to several issues: insufficient delay for IndexedDB to load persisted data, reactive observers being set up after the initial render, and rendering functions not gracefully handling missing or malformed data. Additionally, a `document` reference in `journal.js` broke Node.js test environments, hindering debugging. This PR addresses these by adjusting Y.js initialization timing, reordering render calls, adding data validation, and ensuring test compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe8277c7-96f8-4ca3-af0f-fe5d0b134291">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe8277c7-96f8-4ca3-af0f-fe5d0b134291">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>