### PR TITLE
Fix openai api key saving and test button

### DIFF
--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -20,10 +20,10 @@ export const renderSettingsForm = (formOrSettings, settings = null) => {
     settingsData = settings;
   }
   
-  // API Key setting - try form-based access first, then try different ID patterns
+  // API Key setting - try form-based access first, then fallback to document query
   const apiKeyInput = form ? 
     form.querySelector('[name="openai-api-key"]') : 
-    (document.getElementById('openai-api-key') || document.getElementById('api-key'));
+    document.getElementById('openai-api-key');
   if (apiKeyInput) {
     apiKeyInput.value = settingsData['openai-api-key'] || '';
   }

--- a/settings.html
+++ b/settings.html
@@ -152,13 +152,13 @@
                         <h3 class="settings-subsection-title">Configuration</h3>
                         
                         <div class="form-group">
-                            <label for="api-key" class="form-label">
+                            <label for="openai-api-key" class="form-label">
                                 OpenAI API Key
                             </label>
                             <input 
                                 type="password" 
-                                id="api-key" 
-                                name="api-key"
+                                id="openai-api-key" 
+                                name="openai-api-key"
                                 class="form-input" 
                                 placeholder="sk-..."
                                 autocomplete="off"

--- a/test/settings-views.test.js
+++ b/test/settings-views.test.js
@@ -12,9 +12,9 @@ describe('Settings Views Module', function() {
     // Set up a clean DOM environment for each test
     document.body.innerHTML = `
       <form id="settings-form">
-        <input type="text" id="api-key" />
-        <input type="checkbox" id="ai-enabled" />
-        <input type="text" id="sync-server" />
+        <input type="text" id="openai-api-key" name="openai-api-key" />
+        <input type="checkbox" id="ai-enabled" name="ai-enabled" />
+        <input type="text" id="sync-server-url" name="sync-server-url" />
       </form>
       <div id="connection-status"></div>
       <div id="test-container"></div>
@@ -29,7 +29,7 @@ describe('Settings Views Module', function() {
 
       SettingsViews.renderSettingsForm(settings);
 
-      const apiKeyInput = document.getElementById('api-key');
+      const apiKeyInput = document.getElementById('openai-api-key');
       expect(apiKeyInput.value).to.equal('sk-test123');
     });
 
@@ -40,7 +40,7 @@ describe('Settings Views Module', function() {
 
       SettingsViews.renderSettingsForm(settings);
 
-      const apiKeyInput = document.getElementById('api-key');
+      const apiKeyInput = document.getElementById('openai-api-key');
       expect(apiKeyInput.value).to.equal('');
     });
 
@@ -49,7 +49,7 @@ describe('Settings Views Module', function() {
 
       SettingsViews.renderSettingsForm(settings);
 
-      const apiKeyInput = document.getElementById('api-key');
+      const apiKeyInput = document.getElementById('openai-api-key');
       expect(apiKeyInput.value).to.equal('');
     });
 
@@ -88,31 +88,31 @@ describe('Settings Views Module', function() {
 
     it('should populate sync server input', function() {
       const settings = {
-        'dnd-journal-sync-server': 'wss://test-server.com'
+        'sync-server-url': 'wss://test-server.com'
       };
 
       SettingsViews.renderSettingsForm(settings);
 
-      const syncServerInput = document.getElementById('sync-server');
+      const syncServerInput = document.getElementById('sync-server-url');
       expect(syncServerInput.value).to.equal('wss://test-server.com');
     });
 
     it('should handle empty sync server', function() {
       const settings = {
-        'dnd-journal-sync-server': ''
+        'sync-server-url': ''
       };
 
       SettingsViews.renderSettingsForm(settings);
 
-      const syncServerInput = document.getElementById('sync-server');
+      const syncServerInput = document.getElementById('sync-server-url');
       expect(syncServerInput.value).to.equal('');
     });
 
     it('should handle missing form elements gracefully', function() {
       // Remove form elements
-      document.getElementById('api-key').remove();
+      document.getElementById('openai-api-key').remove();
       document.getElementById('ai-enabled').remove();
-      document.getElementById('sync-server').remove();
+      document.getElementById('sync-server-url').remove();
 
       const settings = {
         'openai-api-key': 'sk-test',
@@ -139,14 +139,14 @@ describe('Settings Views Module', function() {
       const settings = {
         'openai-api-key': 'sk-complete-test',
         'ai-enabled': true,
-        'dnd-journal-sync-server': 'wss://complete-test.com'
+        'sync-server-url': 'wss://complete-test.com'
       };
 
       SettingsViews.renderSettingsForm(settings);
 
-      expect(document.getElementById('api-key').value).to.equal('sk-complete-test');
+      expect(document.getElementById('openai-api-key').value).to.equal('sk-complete-test');
       expect(document.getElementById('ai-enabled').checked).to.be.true;
-      expect(document.getElementById('sync-server').value).to.equal('wss://complete-test.com');
+      expect(document.getElementById('sync-server-url').value).to.equal('wss://complete-test.com');
     });
   });
 


### PR DESCRIPTION
Fixes OpenAI API key settings saving and enables real-time API key validation.

The previous implementation had a mismatch in HTML form field names/IDs and JavaScript expectations, causing settings not to save. Additionally, the "Test API Key" button only checked a local flag, not the actual key's validity with OpenAI. This PR corrects these issues, re-enables notifications, and updates related tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-a798cc26-1a6a-4a30-932c-38696b8cf47a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a798cc26-1a6a-4a30-932c-38696b8cf47a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>