### PR TITLE
Add newline support to ai prompt

### DIFF
--- a/css/components/ai-prompt.css
+++ b/css/components/ai-prompt.css
@@ -57,6 +57,16 @@
   margin: 0;
 }
 
+/* Formatted text elements within AI prompt */
+.ai-prompt__text strong {
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.ai-prompt__text br {
+  line-height: var(--line-height-normal);
+}
+
 /* Loading state */
 .ai-prompt__text.loading {
   color: var(--color-text-muted);
@@ -71,10 +81,28 @@
   margin: 0;
 }
 
+.ai-prompt__empty-state strong {
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+}
+
+.ai-prompt__empty-state br {
+  line-height: var(--line-height-normal);
+}
+
 /* Error state */
 .ai-prompt__error-state {
   color: var(--color-text-muted);
   font-style: italic;
   text-align: center;
   margin: 0;
+}
+
+.ai-prompt__error-state strong {
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+}
+
+.ai-prompt__error-state br {
+  line-height: var(--line-height-normal);
 }

--- a/js/journal-views.js
+++ b/js/journal-views.js
@@ -1,5 +1,5 @@
 // Journal Views - Pure Rendering Functions for Journal Page
-import { parseMarkdown, formatDate, sortEntriesByDate, getFormData } from './utils.js';
+import { parseMarkdown, formatDate, sortEntriesByDate, getFormData, formatAIPromptText } from './utils.js';
 import {
   getCachedJournalEntries,
   getCachedCharacterData,
@@ -365,7 +365,7 @@ export const showAIPromptAPINotAvailable = (aiPromptElement, regenerateBtn = nul
   if (!aiPromptElement) return;
   
   aiPromptElement.className = 'ai-prompt__empty-state';
-  aiPromptElement.textContent = 'AI features require an API key to be configured in Settings.';
+  aiPromptElement.innerHTML = formatAIPromptText('AI features require an API key to be configured in Settings.');
   
   // Disable regenerate button
   if (regenerateBtn) {
@@ -378,7 +378,7 @@ export const showAIPromptNoContext = (aiPromptElement, regenerateBtn = null) => 
   if (!aiPromptElement) return;
   
   aiPromptElement.className = 'ai-prompt__empty-state';
-  aiPromptElement.textContent = 'Add some character details or journal entries to get personalized reflection questions.';
+  aiPromptElement.innerHTML = formatAIPromptText('Add some character details or journal entries to get personalized reflection questions.');
   
   // Disable regenerate button
   if (regenerateBtn) {
@@ -391,7 +391,7 @@ export const showAIPromptLoading = (aiPromptElement, regenerateBtn = null) => {
   if (!aiPromptElement) return;
   
   aiPromptElement.className = 'ai-prompt__text loading';
-  aiPromptElement.textContent = 'Generating your personalized reflection questions...';
+  aiPromptElement.innerHTML = formatAIPromptText('Generating your personalized reflection questions...');
   
   // Disable regenerate button while loading
   if (regenerateBtn) {
@@ -404,7 +404,7 @@ export const showAIPromptQuestions = (aiPromptElement, questions, regenerateBtn 
   if (!aiPromptElement) return;
   
   aiPromptElement.className = 'ai-prompt__text';
-  aiPromptElement.textContent = questions;
+  aiPromptElement.innerHTML = formatAIPromptText(questions);
   
   // Enable regenerate button
   if (regenerateBtn) {
@@ -417,7 +417,7 @@ export const showAIPromptError = (aiPromptElement, regenerateBtn = null) => {
   if (!aiPromptElement) return;
   
   aiPromptElement.className = 'ai-prompt__error-state';
-  aiPromptElement.textContent = 'Unable to generate reflection questions. Please try again.';
+  aiPromptElement.innerHTML = formatAIPromptText('Unable to generate reflection questions. Please try again.');
   
   // Enable regenerate button to allow retry
   if (regenerateBtn) {
@@ -447,7 +447,7 @@ export const renderCachedJournalContent = (elements) => {
   
   // Show loading indicator for real-time content
   if (aiPromptText) {
-    aiPromptText.textContent = 'Loading writing prompt...';
+    aiPromptText.innerHTML = formatAIPromptText('Loading writing prompt...');
   }
 };
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -112,6 +112,18 @@ export const parseMarkdown = (text) => {
     .replace(/__LINE_BREAK__/g, '<br>'); // Single line breaks
 };
 
+// Simple text formatter for AI prompts - supports newlines and basic formatting
+export const formatAIPromptText = (text) => {
+  if (!text) return '';
+  
+  return text
+    .replace(/^\d+\.\s/gm, '<strong>$&</strong>') // Numbered list items (bold the number) - do this first
+    .replace(/\n\n/g, '__PARAGRAPH__') // Paragraph breaks
+    .replace(/\n/g, '<br>') // Line breaks
+    .replace(/__PARAGRAPH__/g, '<br><br>') // Convert paragraph breaks
+    .trim();
+};
+
 // Pure function to get form data from any form
 export const getFormData = (form) => {
   // Try FormData first, fallback to manual extraction for test environments

--- a/test/journal-views.test.js
+++ b/test/journal-views.test.js
@@ -540,7 +540,7 @@ describe('Journal Views Module', function() {
         JournalViews.renderAIPrompt(testElement, aiPromptState, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__empty-state');
-        expect(testElement.textContent).to.equal('AI features require an API key to be configured in Settings.');
+        expect(testElement.innerHTML).to.equal('AI features require an API key to be configured in Settings.');
         expect(testButton.disabled).to.be.true;
       });
 
@@ -550,7 +550,7 @@ describe('Journal Views Module', function() {
         JournalViews.renderAIPrompt(testElement, aiPromptState, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__empty-state');
-        expect(testElement.textContent).to.equal('Add some character details or journal entries to get personalized reflection questions.');
+        expect(testElement.innerHTML).to.equal('Add some character details or journal entries to get personalized reflection questions.');
         expect(testButton.disabled).to.be.true;
       });
 
@@ -560,7 +560,7 @@ describe('Journal Views Module', function() {
         JournalViews.renderAIPrompt(testElement, aiPromptState, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__text loading');
-        expect(testElement.textContent).to.equal('Generating your personalized reflection questions...');
+        expect(testElement.innerHTML).to.equal('Generating your personalized reflection questions...');
         expect(testButton.disabled).to.be.true;
       });
 
@@ -571,7 +571,7 @@ describe('Journal Views Module', function() {
         JournalViews.renderAIPrompt(testElement, aiPromptState, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__text');
-        expect(testElement.textContent).to.equal(questions);
+        expect(testElement.innerHTML).to.equal(questions);
         expect(testButton.disabled).to.be.false;
       });
 
@@ -581,7 +581,7 @@ describe('Journal Views Module', function() {
         JournalViews.renderAIPrompt(testElement, aiPromptState, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__error-state');
-        expect(testElement.textContent).to.equal('Unable to generate reflection questions. Please try again.');
+        expect(testElement.innerHTML).to.equal('Unable to generate reflection questions. Please try again.');
         expect(testButton.disabled).to.be.false;
       });
 
@@ -591,7 +591,7 @@ describe('Journal Views Module', function() {
         JournalViews.renderAIPrompt(testElement, aiPromptState, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__error-state');
-        expect(testElement.textContent).to.equal('Unable to generate reflection questions. Please try again.');
+        expect(testElement.innerHTML).to.equal('Unable to generate reflection questions. Please try again.');
         expect(testButton.disabled).to.be.false;
       });
 
@@ -614,7 +614,7 @@ describe('Journal Views Module', function() {
         JournalViews.showAIPromptAPINotAvailable(testElement, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__empty-state');
-        expect(testElement.textContent).to.equal('AI features require an API key to be configured in Settings.');
+        expect(testElement.innerHTML).to.equal('AI features require an API key to be configured in Settings.');
         expect(testButton.disabled).to.be.true;
       });
 
@@ -632,7 +632,7 @@ describe('Journal Views Module', function() {
         JournalViews.showAIPromptNoContext(testElement, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__empty-state');
-        expect(testElement.textContent).to.equal('Add some character details or journal entries to get personalized reflection questions.');
+        expect(testElement.innerHTML).to.equal('Add some character details or journal entries to get personalized reflection questions.');
         expect(testButton.disabled).to.be.true;
       });
 
@@ -646,7 +646,7 @@ describe('Journal Views Module', function() {
         JournalViews.showAIPromptLoading(testElement, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__text loading');
-        expect(testElement.textContent).to.equal('Generating your personalized reflection questions...');
+        expect(testElement.innerHTML).to.equal('Generating your personalized reflection questions...');
         expect(testButton.disabled).to.be.true;
       });
 
@@ -662,12 +662,25 @@ describe('Journal Views Module', function() {
         JournalViews.showAIPromptQuestions(testElement, questions, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__text');
-        expect(testElement.textContent).to.equal(questions);
+        expect(testElement.innerHTML).to.equal(questions);
         expect(testButton.disabled).to.be.false;
       });
 
       it('should handle missing element', function() {
         expect(() => JournalViews.showAIPromptQuestions(null, 'questions', testButton)).to.not.throw();
+      });
+
+      it('should format questions with newlines and numbered lists', function() {
+        const questions = '1. What drives your character?\n\n2. How do they handle conflict?\n\n3. What are their deepest fears?';
+        
+        JournalViews.showAIPromptQuestions(testElement, questions, testButton);
+        
+        expect(testElement.className).to.equal('ai-prompt__text');
+        expect(testElement.innerHTML).to.include('<strong>1. </strong>What drives your character?');
+        expect(testElement.innerHTML).to.include('<br><br>');
+        expect(testElement.innerHTML).to.include('<strong>2. </strong>How do they handle conflict?');
+        expect(testElement.innerHTML).to.include('<strong>3. </strong>What are their deepest fears?');
+        expect(testButton.disabled).to.be.false;
       });
     });
 
@@ -676,7 +689,7 @@ describe('Journal Views Module', function() {
         JournalViews.showAIPromptError(testElement, testButton);
         
         expect(testElement.className).to.equal('ai-prompt__error-state');
-        expect(testElement.textContent).to.equal('Unable to generate reflection questions. Please try again.');
+        expect(testElement.innerHTML).to.equal('Unable to generate reflection questions. Please try again.');
         expect(testButton.disabled).to.be.false;
       });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -287,4 +287,56 @@ describe('Utils Module', function() {
       expect(html).to.include('<br>');
     });
   });
+
+  describe('formatAIPromptText', function() {
+    it('should convert line breaks to <br> tags', function() {
+      const text = 'Line 1\nLine 2\nLine 3';
+      const html = Utils.formatAIPromptText(text);
+      
+      expect(html).to.equal('Line 1<br>Line 2<br>Line 3');
+    });
+
+    it('should convert double line breaks to double <br> tags', function() {
+      const text = 'Paragraph 1\n\nParagraph 2';
+      const html = Utils.formatAIPromptText(text);
+      
+      expect(html).to.equal('Paragraph 1<br><br>Paragraph 2');
+    });
+
+    it('should format numbered list items', function() {
+      const text = '1. First question\n2. Second question\n3. Third question';
+      const html = Utils.formatAIPromptText(text);
+      
+      expect(html).to.include('<strong>1. </strong>First question');
+      expect(html).to.include('<strong>2. </strong>Second question');
+      expect(html).to.include('<strong>3. </strong>Third question');
+    });
+
+    it('should handle empty content', function() {
+      const html = Utils.formatAIPromptText('');
+      expect(html).to.equal('');
+    });
+
+    it('should handle null content', function() {
+      const html = Utils.formatAIPromptText(null);
+      expect(html).to.equal('');
+    });
+
+    it('should trim whitespace', function() {
+      const text = '  Some content with spaces  ';
+      const html = Utils.formatAIPromptText(text);
+      
+      expect(html).to.equal('Some content with spaces');
+    });
+
+    it('should handle complex formatting', function() {
+      const text = '1. What is your character\'s greatest fear?\n\n2. How has their past shaped them?\n\n3. What drives them forward?';
+      const html = Utils.formatAIPromptText(text);
+      
+      expect(html).to.include('<strong>1. </strong>What is your character\'s greatest fear?');
+      expect(html).to.include('<br><br>');
+      expect(html).to.include('<strong>2. </strong>How has their past shaped them?');
+      expect(html).to.include('<strong>3. </strong>What drives them forward?');
+    });
+  });
 });


### PR DESCRIPTION
Enable simple formatting (newlines, paragraph breaks, bolded numbered lists) for AI prompts to improve readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba4389ac-d8fa-4f0c-b631-52b362010f16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba4389ac-d8fa-4f0c-b631-52b362010f16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>