### PR TITLE
Fix ai prompt button in settings

### DIFF
--- a/js/ai.js
+++ b/js/ai.js
@@ -13,17 +13,22 @@ export const isAIEnabled = () => {
   return Boolean(enabled && apiKey);
 };
 
-// Simple AI call function
-const callAI = async (systemPrompt, userPrompt) => {
-  const state = getYjsState();
-  const apiKey = getSetting(state, 'openai-api-key', '');
-  
-  const messages = systemPrompt 
+// Build messages array for OpenAI API
+export const buildMessages = (systemPrompt, userPrompt) => {
+  return systemPrompt 
     ? [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt }
       ]
     : [{ role: 'user', content: userPrompt }];
+};
+
+// Simple AI call function
+const callAI = async (systemPrompt, userPrompt) => {
+  const state = getYjsState();
+  const apiKey = getSetting(state, 'openai-api-key', '');
+  
+  const messages = buildMessages(systemPrompt, userPrompt);
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',

--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -34,6 +34,14 @@ export const renderSettingsForm = (formOrSettings, settings = null) => {
     aiEnabledCheckbox.checked = settingsData['ai-enabled'] === 'true' || settingsData['ai-enabled'] === true;
   }
   
+  // Update show AI prompt button state
+  const showPromptButton = document.getElementById('show-ai-prompt');
+  if (showPromptButton) {
+    const hasApiKey = settingsData['openai-api-key'] && settingsData['openai-api-key'].trim().length > 0;
+    const aiEnabled = settingsData['ai-enabled'] === 'true' || settingsData['ai-enabled'] === true;
+    showPromptButton.disabled = !hasApiKey || !aiEnabled;
+  }
+  
   // Sync server setting - try different ID patterns and key names
   const syncServerInput = form ? 
     form.querySelector('[name="sync-server-url"]') : 

--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -98,7 +98,7 @@ export const setTestConnectionLoading = (isLoading) => {
 };
 
 // Render AI prompt preview
-export const renderAIPromptPreview = (aiEnabled, promptPreview = null, contextData = null) => {
+export const renderAIPromptPreview = (aiEnabled, promptPreview = null) => {
   const promptPreviewElement = document.getElementById('ai-prompt-preview');
   const promptContentElement = document.getElementById('ai-prompt-content');
   
@@ -132,50 +132,16 @@ export const renderAIPromptPreview = (aiEnabled, promptPreview = null, contextDa
       </div>
     `;
   } else {
-    // Show the full prompt with actual context and data
-    const characterData = contextData?.character || {};
-    const entriesData = contextData?.entries || [];
-    
+    // Show just the final prompt
     promptContentElement.innerHTML = `
       <div class="system-prompt">
         <h4>System Prompt</h4>
-        <div style="white-space: pre-wrap;">${promptPreview.systemPrompt}</div>
-      </div>
-      
-      <div class="system-prompt">
-        <h4>Current Data Used for Context</h4>
-        <div style="white-space: pre-wrap; font-family: monospace; font-size: 0.9em;">
-          <strong>Character:</strong>
-          Name: ${characterData.name || 'Not set'}
-          Race: ${characterData.race || 'Not set'}
-          Class: ${characterData.class || 'Not set'}
-          
-          <strong>Backstory:</strong> ${characterData.backstory ? (characterData.backstory.length > 100 ? characterData.backstory.substring(0, 100) + '...' : characterData.backstory) : 'Not set'}
-          
-          <strong>Notes:</strong> ${characterData.notes ? (characterData.notes.length > 100 ? characterData.notes.substring(0, 100) + '...' : characterData.notes) : 'Not set'}
-          
-          <strong>Journal Entries:</strong> ${entriesData.length} entries
-          ${entriesData.length > 0 ? entriesData.slice(-3).map(entry => `- ${entry.title}: ${entry.content.substring(0, 80)}${entry.content.length > 80 ? '...' : ''}`).join('\n          ') : 'No entries yet'}
-        </div>
-      </div>
-      
-      <div class="system-prompt">
-        <h4>Built Context String</h4>
-        <div style="white-space: pre-wrap; font-family: monospace; font-size: 0.9em;">${promptPreview.context}</div>
+        <div>${promptPreview.systemPrompt}</div>
       </div>
       
       <div class="user-prompt">
-        <h4>Complete User Prompt (sent to OpenAI)</h4>
-        <div style="white-space: pre-wrap; font-family: monospace; font-size: 0.9em;">${promptPreview.userPrompt}</div>
-      </div>
-      
-      <div class="user-prompt">
-        <h4>Summarization Prompts</h4>
-        <p><strong>Journal Entry Template:</strong></p>
-        <div style="font-family: monospace; font-size: 0.9em;">${PROMPTS.summarization.entry('[ENTRY_TEXT]')}</div>
-        <br>
-        <p><strong>Character Template:</strong></p>
-        <div style="font-family: monospace; font-size: 0.9em;">${PROMPTS.summarization.character('[CHARACTER_TEXT]')}</div>
+        <h4>User Prompt</h4>
+        <div>${promptPreview.userPrompt}</div>
       </div>
     `;
   }

--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -4,7 +4,6 @@ import {
   getCachedSettings,
   getFormDataForPage
 } from './navigation-cache.js';
-import { PROMPTS } from './prompts.js';
 
 // Render settings form with current data
 export const renderSettingsForm = (formOrSettings, settings = null) => {
@@ -98,7 +97,7 @@ export const setTestConnectionLoading = (isLoading) => {
 };
 
 // Render AI prompt preview
-export const renderAIPromptPreview = (aiEnabled, promptPreview = null) => {
+export const renderAIPromptPreview = (aiEnabled, messages = null) => {
   const promptPreviewElement = document.getElementById('ai-prompt-preview');
   const promptContentElement = document.getElementById('ai-prompt-content');
   
@@ -114,36 +113,23 @@ export const renderAIPromptPreview = (aiEnabled, promptPreview = null) => {
         <p>Please configure your OpenAI API key and enable AI features to view prompts.</p>
       </div>
     `;
-  } else if (!promptPreview) {
+  } else if (!messages) {
     promptContentElement.innerHTML = `
       <div class="system-prompt">
         <p><strong>No context available.</strong></p>
-        <p>Add some journal entries and character information to see a full prompt preview with context.</p>
-      </div>
-      
-      <div class="user-prompt">
-        <h4>Available Prompt Templates</h4>
-        <p><strong>Storytelling System:</strong></p>
-        <div>${PROMPTS.storytelling.system}</div>
-        <br>
-        <p><strong>Summarization Templates:</strong></p>
-        <div>• Journal Entry: ${PROMPTS.summarization.entry('[YOUR_ENTRY_TEXT]')}</div>
-        <div>• Character Info: ${PROMPTS.summarization.character('[YOUR_CHARACTER_TEXT]')}</div>
+        <p>Add some journal entries and character information to see prompts.</p>
       </div>
     `;
   } else {
-    // Show just the final prompt
-    promptContentElement.innerHTML = `
-      <div class="system-prompt">
-        <h4>System Prompt</h4>
-        <div>${promptPreview.systemPrompt}</div>
+    // Show the exact messages sent to OpenAI
+    const content = messages.map(msg => `
+      <div class="${msg.role === 'system' ? 'system-prompt' : 'user-prompt'}">
+        <h4>${msg.role === 'system' ? 'System' : 'User'}</h4>
+        <div>${msg.content}</div>
       </div>
-      
-      <div class="user-prompt">
-        <h4>User Prompt</h4>
-        <div>${promptPreview.userPrompt}</div>
-      </div>
-    `;
+    `).join('');
+    
+    promptContentElement.innerHTML = content;
   }
   
   promptPreviewElement.style.display = 'block';

--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -4,6 +4,7 @@ import {
   getCachedSettings,
   getFormDataForPage
 } from './navigation-cache.js';
+import { PROMPTS } from './prompts.js';
 
 // Render settings form with current data
 export const renderSettingsForm = (formOrSettings, settings = null) => {
@@ -94,6 +95,45 @@ export const setTestConnectionLoading = (isLoading) => {
     testBtn.disabled = isLoading;
     testBtn.textContent = isLoading ? 'Testing...' : 'Test Connection';
   }
+};
+
+// Render AI prompt preview
+export const renderAIPromptPreview = (aiEnabled) => {
+  const promptPreviewElement = document.getElementById('ai-prompt-preview');
+  const promptContentElement = document.getElementById('ai-prompt-content');
+  
+  if (!promptPreviewElement || !promptContentElement) {
+    console.warn('AI prompt preview elements not found');
+    return;
+  }
+  
+  if (!aiEnabled) {
+    promptContentElement.innerHTML = `
+      <div class="system-prompt">
+        <p><strong>AI features are not enabled.</strong></p>
+        <p>Please configure your OpenAI API key and enable AI features to view prompts.</p>
+      </div>
+    `;
+  } else {
+    // Show the current prompts used by the system
+    promptContentElement.innerHTML = `
+      <div class="system-prompt">
+        <h4>Storytelling System Prompt</h4>
+        <div>${PROMPTS.storytelling.system}</div>
+      </div>
+      
+      <div class="user-prompt">
+        <h4>Summarization Prompts</h4>
+        <p><strong>Journal Entry:</strong></p>
+        <div>Summarize this D&D journal entry in approximately 100 words, capturing the key events, decisions, and character developments: [YOUR_ENTRY_TEXT]</div>
+        <br>
+        <p><strong>Character Information:</strong></p>
+        <div>Summarize this D&D character information in approximately 50 words: [YOUR_CHARACTER_TEXT]</div>
+      </div>
+    `;
+  }
+  
+  promptPreviewElement.style.display = 'block';
 };
 
 // Pure function to render cached settings content immediately

--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -98,7 +98,7 @@ export const setTestConnectionLoading = (isLoading) => {
 };
 
 // Render AI prompt preview
-export const renderAIPromptPreview = (aiEnabled, promptPreview = null) => {
+export const renderAIPromptPreview = (aiEnabled, promptPreview = null, contextData = null) => {
   const promptPreviewElement = document.getElementById('ai-prompt-preview');
   const promptContentElement = document.getElementById('ai-prompt-content');
   
@@ -132,32 +132,50 @@ export const renderAIPromptPreview = (aiEnabled, promptPreview = null) => {
       </div>
     `;
   } else {
-    // Show the full prompt with actual context
+    // Show the full prompt with actual context and data
+    const characterData = contextData?.character || {};
+    const entriesData = contextData?.entries || [];
+    
     promptContentElement.innerHTML = `
       <div class="system-prompt">
         <h4>System Prompt</h4>
-        <div>${promptPreview.systemPrompt}</div>
+        <div style="white-space: pre-wrap;">${promptPreview.systemPrompt}</div>
       </div>
       
-      ${promptPreview.context ? `
-        <div class="system-prompt">
-          <h4>Context Used</h4>
-          <div style="white-space: pre-wrap;">${promptPreview.context}</div>
+      <div class="system-prompt">
+        <h4>Current Data Used for Context</h4>
+        <div style="white-space: pre-wrap; font-family: monospace; font-size: 0.9em;">
+          <strong>Character:</strong>
+          Name: ${characterData.name || 'Not set'}
+          Race: ${characterData.race || 'Not set'}
+          Class: ${characterData.class || 'Not set'}
+          
+          <strong>Backstory:</strong> ${characterData.backstory ? (characterData.backstory.length > 100 ? characterData.backstory.substring(0, 100) + '...' : characterData.backstory) : 'Not set'}
+          
+          <strong>Notes:</strong> ${characterData.notes ? (characterData.notes.length > 100 ? characterData.notes.substring(0, 100) + '...' : characterData.notes) : 'Not set'}
+          
+          <strong>Journal Entries:</strong> ${entriesData.length} entries
+          ${entriesData.length > 0 ? entriesData.slice(-3).map(entry => `- ${entry.title}: ${entry.content.substring(0, 80)}${entry.content.length > 80 ? '...' : ''}`).join('\n          ') : 'No entries yet'}
         </div>
-      ` : ''}
+      </div>
+      
+      <div class="system-prompt">
+        <h4>Built Context String</h4>
+        <div style="white-space: pre-wrap; font-family: monospace; font-size: 0.9em;">${promptPreview.context}</div>
+      </div>
       
       <div class="user-prompt">
-        <h4>Complete User Prompt (with context)</h4>
-        <div style="white-space: pre-wrap;">${promptPreview.userPrompt}</div>
+        <h4>Complete User Prompt (sent to OpenAI)</h4>
+        <div style="white-space: pre-wrap; font-family: monospace; font-size: 0.9em;">${promptPreview.userPrompt}</div>
       </div>
       
       <div class="user-prompt">
         <h4>Summarization Prompts</h4>
         <p><strong>Journal Entry Template:</strong></p>
-        <div>${PROMPTS.summarization.entry('[ENTRY_TEXT]')}</div>
+        <div style="font-family: monospace; font-size: 0.9em;">${PROMPTS.summarization.entry('[ENTRY_TEXT]')}</div>
         <br>
         <p><strong>Character Template:</strong></p>
-        <div>${PROMPTS.summarization.character('[CHARACTER_TEXT]')}</div>
+        <div style="font-family: monospace; font-size: 0.9em;">${PROMPTS.summarization.character('[CHARACTER_TEXT]')}</div>
       </div>
     `;
   }

--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -98,7 +98,7 @@ export const setTestConnectionLoading = (isLoading) => {
 };
 
 // Render AI prompt preview
-export const renderAIPromptPreview = (aiEnabled) => {
+export const renderAIPromptPreview = (aiEnabled, promptPreview = null) => {
   const promptPreviewElement = document.getElementById('ai-prompt-preview');
   const promptContentElement = document.getElementById('ai-prompt-content');
   
@@ -114,21 +114,50 @@ export const renderAIPromptPreview = (aiEnabled) => {
         <p>Please configure your OpenAI API key and enable AI features to view prompts.</p>
       </div>
     `;
-  } else {
-    // Show the current prompts used by the system
+  } else if (!promptPreview) {
     promptContentElement.innerHTML = `
       <div class="system-prompt">
-        <h4>Storytelling System Prompt</h4>
+        <p><strong>No context available.</strong></p>
+        <p>Add some journal entries and character information to see a full prompt preview with context.</p>
+      </div>
+      
+      <div class="user-prompt">
+        <h4>Available Prompt Templates</h4>
+        <p><strong>Storytelling System:</strong></p>
         <div>${PROMPTS.storytelling.system}</div>
+        <br>
+        <p><strong>Summarization Templates:</strong></p>
+        <div>• Journal Entry: ${PROMPTS.summarization.entry('[YOUR_ENTRY_TEXT]')}</div>
+        <div>• Character Info: ${PROMPTS.summarization.character('[YOUR_CHARACTER_TEXT]')}</div>
+      </div>
+    `;
+  } else {
+    // Show the full prompt with actual context
+    promptContentElement.innerHTML = `
+      <div class="system-prompt">
+        <h4>System Prompt</h4>
+        <div>${promptPreview.systemPrompt}</div>
+      </div>
+      
+      ${promptPreview.context ? `
+        <div class="system-prompt">
+          <h4>Context Used</h4>
+          <div style="white-space: pre-wrap;">${promptPreview.context}</div>
+        </div>
+      ` : ''}
+      
+      <div class="user-prompt">
+        <h4>Complete User Prompt (with context)</h4>
+        <div style="white-space: pre-wrap;">${promptPreview.userPrompt}</div>
       </div>
       
       <div class="user-prompt">
         <h4>Summarization Prompts</h4>
-        <p><strong>Journal Entry:</strong></p>
-        <div>Summarize this D&D journal entry in approximately 100 words, capturing the key events, decisions, and character developments: [YOUR_ENTRY_TEXT]</div>
+        <p><strong>Journal Entry Template:</strong></p>
+        <div>${PROMPTS.summarization.entry('[ENTRY_TEXT]')}</div>
         <br>
-        <p><strong>Character Information:</strong></p>
-        <div>Summarize this D&D character information in approximately 50 words: [YOUR_CHARACTER_TEXT]</div>
+        <p><strong>Character Template:</strong></p>
+        <div>${PROMPTS.summarization.character('[CHARACTER_TEXT]')}</div>
       </div>
     `;
   }

--- a/js/settings.js
+++ b/js/settings.js
@@ -20,7 +20,6 @@ import { getFormData } from './utils.js';
 import { saveNavigationCache } from './navigation-cache.js';
 
 import { isAIEnabled, getPromptPreview } from './ai.js';
-import { getContextData } from './context.js';
 
 // State management
 let settingsFormElement = null;
@@ -246,17 +245,15 @@ export const showCurrentAIPrompt = async () => {
     const aiEnabled = isAIEnabled();
     
     if (!aiEnabled) {
-      renderAIPromptPreview(aiEnabled, null, null);
+      renderAIPromptPreview(aiEnabled, null);
       showNotification('AI features not enabled', 'info');
       return;
     }
     
-    // Get current context data
-    showNotification('Building prompt preview...', 'info');
-    const contextData = getContextData();
-    const promptPreview = await getPromptPreview(contextData.character, contextData.entries);
+    // Get prompt preview
+    const promptPreview = await getPromptPreview();
     
-    renderAIPromptPreview(aiEnabled, promptPreview, contextData);
+    renderAIPromptPreview(aiEnabled, promptPreview);
     showNotification('Current AI prompts displayed', 'success');
   } catch (error) {
     console.error('Failed to show AI prompt:', error);

--- a/js/settings.js
+++ b/js/settings.js
@@ -19,7 +19,7 @@ import { getFormData } from './utils.js';
 
 import { saveNavigationCache } from './navigation-cache.js';
 
-import { isAIEnabled, getPromptPreview } from './ai.js';
+import { isAIEnabled, getPromptPreview, buildMessages } from './ai.js';
 
 // State management
 let settingsFormElement = null;
@@ -250,10 +250,11 @@ export const showCurrentAIPrompt = async () => {
       return;
     }
     
-    // Get prompt preview
+    // Get prompt preview using same logic as AI module
     const promptPreview = await getPromptPreview();
+    const messages = promptPreview ? buildMessages(promptPreview.systemPrompt, promptPreview.userPrompt) : null;
     
-    renderAIPromptPreview(aiEnabled, promptPreview);
+    renderAIPromptPreview(aiEnabled, messages);
     showNotification('Current AI prompts displayed', 'success');
   } catch (error) {
     console.error('Failed to show AI prompt:', error);

--- a/js/settings.js
+++ b/js/settings.js
@@ -19,7 +19,7 @@ import { getFormData } from './utils.js';
 
 import { saveNavigationCache } from './navigation-cache.js';
 
-import { isAIEnabled } from './ai.js';
+import { isAIEnabled, getPromptPreview } from './ai.js';
 
 // State management
 let settingsFormElement = null;
@@ -243,13 +243,19 @@ export const testConnection = async (stateParam = null) => {
 export const showCurrentAIPrompt = async () => {
   try {
     const aiEnabled = isAIEnabled();
-    renderAIPromptPreview(aiEnabled);
     
-    if (aiEnabled) {
-      showNotification('Current AI prompts displayed', 'success');
-    } else {
+    if (!aiEnabled) {
+      renderAIPromptPreview(aiEnabled, null);
       showNotification('AI features not enabled', 'info');
+      return;
     }
+    
+    // Get current prompt preview with actual context
+    showNotification('Building prompt preview...', 'info');
+    const promptPreview = await getPromptPreview();
+    
+    renderAIPromptPreview(aiEnabled, promptPreview);
+    showNotification('Current AI prompts displayed', 'success');
   } catch (error) {
     console.error('Failed to show AI prompt:', error);
     showNotification('Error displaying AI prompts', 'error');

--- a/js/settings.js
+++ b/js/settings.js
@@ -11,15 +11,15 @@ import {
   renderSettingsForm,
   renderConnectionStatus,
   showNotification,
-  renderCachedSettingsContent
+  renderCachedSettingsContent,
+  renderAIPromptPreview
 } from './settings-views.js';
 
 import { getFormData } from './utils.js';
 
 import { saveNavigationCache } from './navigation-cache.js';
 
-import { isAIEnabled, getPromptPreview } from './ai.js';
-import { PROMPTS } from './prompts.js';
+import { isAIEnabled } from './ai.js';
 
 // State management
 let settingsFormElement = null;
@@ -242,46 +242,14 @@ export const testConnection = async (stateParam = null) => {
 // Show current AI prompt
 export const showCurrentAIPrompt = async () => {
   try {
-    const promptPreviewElement = document.getElementById('ai-prompt-preview');
-    const promptContentElement = document.getElementById('ai-prompt-content');
+    const aiEnabled = isAIEnabled();
+    renderAIPromptPreview(aiEnabled);
     
-    if (!promptPreviewElement || !promptContentElement) {
-      showNotification('Prompt preview elements not found', 'error');
-      return;
+    if (aiEnabled) {
+      showNotification('Current AI prompts displayed', 'success');
+    } else {
+      showNotification('AI features not enabled', 'info');
     }
-    
-    if (!isAIEnabled()) {
-      promptContentElement.innerHTML = `
-        <div class="prompt-section">
-          <p><strong>AI features are not enabled.</strong></p>
-          <p>Please configure your OpenAI API key and enable AI features to view prompts.</p>
-        </div>
-      `;
-      promptPreviewElement.style.display = 'block';
-      return;
-    }
-    
-    // Show the current prompts used by the system
-    const promptContent = `
-      <div class="system-prompt">
-        <h4>Storytelling System Prompt</h4>
-        <div>${PROMPTS.storytelling.system}</div>
-      </div>
-      
-      <div class="user-prompt">
-        <h4>Summarization Prompts</h4>
-        <p><strong>Journal Entry:</strong></p>
-        <div>Summarize this D&D journal entry in approximately 100 words, capturing the key events, decisions, and character developments: [YOUR_ENTRY_TEXT]</div>
-        <br>
-        <p><strong>Character Information:</strong></p>
-        <div>Summarize this D&D character information in approximately 50 words: [YOUR_CHARACTER_TEXT]</div>
-      </div>
-    `;
-    
-    promptContentElement.innerHTML = promptContent;
-    promptPreviewElement.style.display = 'block';
-    
-    showNotification('Current AI prompts displayed', 'success');
   } catch (error) {
     console.error('Failed to show AI prompt:', error);
     showNotification('Error displaying AI prompts', 'error');

--- a/js/settings.js
+++ b/js/settings.js
@@ -20,6 +20,7 @@ import { getFormData } from './utils.js';
 import { saveNavigationCache } from './navigation-cache.js';
 
 import { isAIEnabled, getPromptPreview } from './ai.js';
+import { getContextData } from './context.js';
 
 // State management
 let settingsFormElement = null;
@@ -245,16 +246,17 @@ export const showCurrentAIPrompt = async () => {
     const aiEnabled = isAIEnabled();
     
     if (!aiEnabled) {
-      renderAIPromptPreview(aiEnabled, null);
+      renderAIPromptPreview(aiEnabled, null, null);
       showNotification('AI features not enabled', 'info');
       return;
     }
     
-    // Get current prompt preview with actual context
+    // Get current context data
     showNotification('Building prompt preview...', 'info');
-    const promptPreview = await getPromptPreview();
+    const contextData = getContextData();
+    const promptPreview = await getPromptPreview(contextData.character, contextData.entries);
     
-    renderAIPromptPreview(aiEnabled, promptPreview);
+    renderAIPromptPreview(aiEnabled, promptPreview, contextData);
     showNotification('Current AI prompts displayed', 'success');
   } catch (error) {
     console.error('Failed to show AI prompt:', error);

--- a/js/settings.js
+++ b/js/settings.js
@@ -18,7 +18,8 @@ import { getFormData } from './utils.js';
 
 import { saveNavigationCache } from './navigation-cache.js';
 
-import { isAIEnabled } from './ai.js';
+import { isAIEnabled, getPromptPreview } from './ai.js';
+import { PROMPTS } from './prompts.js';
 
 // State management
 let settingsFormElement = null;
@@ -127,6 +128,15 @@ const setupFormHandlers = () => {
     });
     testConnectionButton.setAttribute('data-handler-attached', 'true');
   }
+  
+  const showAIPromptButton = document.getElementById('show-ai-prompt');
+  if (showAIPromptButton && !showAIPromptButton.hasAttribute('data-handler-attached')) {
+    showAIPromptButton.addEventListener('click', (e) => {
+      e.preventDefault();
+      showCurrentAIPrompt();
+    });
+    showAIPromptButton.setAttribute('data-handler-attached', 'true');
+  }
 };
 
 // Save settings to Y.js
@@ -226,6 +236,55 @@ export const testConnection = async (stateParam = null) => {
   } catch (error) {
     console.error('Failed to test connection:', error);
     showNotification('Error testing connection', 'error');
+  }
+};
+
+// Show current AI prompt
+export const showCurrentAIPrompt = async () => {
+  try {
+    const promptPreviewElement = document.getElementById('ai-prompt-preview');
+    const promptContentElement = document.getElementById('ai-prompt-content');
+    
+    if (!promptPreviewElement || !promptContentElement) {
+      showNotification('Prompt preview elements not found', 'error');
+      return;
+    }
+    
+    if (!isAIEnabled()) {
+      promptContentElement.innerHTML = `
+        <div class="prompt-section">
+          <p><strong>AI features are not enabled.</strong></p>
+          <p>Please configure your OpenAI API key and enable AI features to view prompts.</p>
+        </div>
+      `;
+      promptPreviewElement.style.display = 'block';
+      return;
+    }
+    
+    // Show the current prompts used by the system
+    const promptContent = `
+      <div class="system-prompt">
+        <h4>Storytelling System Prompt</h4>
+        <div>${PROMPTS.storytelling.system}</div>
+      </div>
+      
+      <div class="user-prompt">
+        <h4>Summarization Prompts</h4>
+        <p><strong>Journal Entry:</strong></p>
+        <div>Summarize this D&D journal entry in approximately 100 words, capturing the key events, decisions, and character developments: [YOUR_ENTRY_TEXT]</div>
+        <br>
+        <p><strong>Character Information:</strong></p>
+        <div>Summarize this D&D character information in approximately 50 words: [YOUR_CHARACTER_TEXT]</div>
+      </div>
+    `;
+    
+    promptContentElement.innerHTML = promptContent;
+    promptPreviewElement.style.display = 'block';
+    
+    showNotification('Current AI prompts displayed', 'success');
+  } catch (error) {
+    console.error('Failed to show AI prompt:', error);
+    showNotification('Error displaying AI prompts', 'error');
   }
 };
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable 'Show Current AI Prompt' button in settings, displaying AI prompts or configuration status.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The button was previously non-functional due to a missing event handler. This PR adds the necessary event listener, manages the button's enabled/disabled state based on AI configuration, and displays the current system prompts or a message if AI is not enabled. The rendering logic has been refactored to `settings-views.js` for better separation of concerns.

---
<a href="https://cursor.com/background-agent?bcId=bc-97900d20-29eb-487d-a8cc-9c36df0bf6af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97900d20-29eb-487d-a8cc-9c36df0bf6af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>