### PR TITLE
Fix character page summaries display

### DIFF
--- a/js/character-views.js
+++ b/js/character-views.js
@@ -60,10 +60,10 @@ export const renderSummaries = (backstorySummary, notesSummary) => {
 };
 
 // Show/hide generate summaries button
-export const toggleGenerateButton = (isAPIAvailable) => {
+export const toggleGenerateButton = (isAPIAvailable, hasContent = false) => {
   const generateBtn = document.getElementById('generate-summaries');
   if (generateBtn) {
-    generateBtn.style.display = isAPIAvailable ? 'inline-block' : 'none';
+    generateBtn.style.display = (isAPIAvailable && hasContent) ? 'inline-block' : 'none';
   }
 };
 

--- a/test/character.test.js
+++ b/test/character.test.js
@@ -135,7 +135,7 @@ describe('Character Page', function() {
     });
 
     it('should display existing summaries', function() {
-      YjsModule.setSummary(state, 'character-backstory', 'A brief summary of backstory');
+      YjsModule.setSummary(state, 'character:backstory', 'A brief summary of backstory');
       
       Character.updateSummariesDisplay(state);
       
@@ -167,7 +167,7 @@ describe('Character Page', function() {
     });
 
     it('should update summaries when Y.js summary data changes', function() {
-      YjsModule.setSummary(state, 'character-backstory', 'Updated summary');
+      YjsModule.setSummary(state, 'character:backstory', 'Updated summary');
       
       Character.updateSummariesDisplay(state);
       

--- a/test/summarization.test.js
+++ b/test/summarization.test.js
@@ -126,7 +126,7 @@ describe('Simple Summarization Module', function() {
       
       const testCases = [
         {
-          key: 'character-backstory',
+          key: 'character:backstory',
           content: 'A detailed character backstory with lots of information about their past, motivations, and relationships.'
         },
         {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable and fix character page summaries by correcting key formats and generation logic.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, summaries were not displayed or generated correctly due to inconsistent summary key formats (e.g., `character-backstory` vs `character:backstory`) and the `generateSummary` function incorrectly hardcoding the field. This PR resolves these inconsistencies, adds a `generateAllSummaries` function, and correctly enables the "Generate Summaries" button based on AI availability and content presence.

---
<a href="https://cursor.com/background-agent?bcId=bc-b54dda09-0aee-4ed2-bb7e-79735e47b99a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b54dda09-0aee-4ed2-bb7e-79735e47b99a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>