### PR TITLE
Enable journal entry summaries by default

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -487,6 +487,36 @@ section {
   margin: 0;
 }
 
+/* Entry summary section */
+.entry-summary-section {
+  margin-top: var(--space-md);
+}
+
+.entry-summary-text {
+  padding: var(--space-md);
+  background: var(--color-gray-50);
+  border-left: 3px solid var(--color-accent);
+  margin-bottom: var(--space-md);
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.entry-summary-text p {
+  margin: 0;
+}
+
+.entry-summary-loading {
+  padding: var(--space-sm);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-style: italic;
+  text-align: center;
+}
+
+.entry-collapsible {
+  margin-top: var(--space-md);
+}
+
 .entry-actions {
   display: flex;
   gap: var(--space-sm);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable journal to show summaries of entries by default with full content in collapsible sections to improve scannability.

---
<a href="https://cursor.com/background-agent?bcId=bc-8825ecf1-0f3c-4b01-a387-a2f4411e8004">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8825ecf1-0f3c-4b01-a387-a2f4411e8004">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>