### PR TITLE
Check surge ignore for node modules

### DIFF
--- a/.surgeignore
+++ b/.surgeignore
@@ -1,2 +1,35 @@
-!node_modules/
+# Exclude server directory
 server/
+
+# Exclude all node_modules except those needed for client import maps
+node_modules/
+!node_modules/yjs/
+!node_modules/y-indexeddb/
+!node_modules/y-websocket/
+!node_modules/y-protocols/
+!node_modules/lib0/
+!node_modules/lodash.debounce/
+!node_modules/ws/
+!node_modules/y-leveldb/
+
+# Exclude test files and development artifacts from included modules
+node_modules/**/test/
+node_modules/**/test.js
+node_modules/**/*.test.js
+node_modules/**/spec/
+node_modules/**/*.spec.js
+node_modules/**/example/
+node_modules/**/examples/
+node_modules/**/demo/
+node_modules/**/demos/
+node_modules/**/bin/
+node_modules/**/.github/
+node_modules/**/CHANGELOG.md
+node_modules/**/README.md
+node_modules/**/LICENSE*
+node_modules/**/*.md
+
+# Exclude common development files
+*.map
+.DS_Store
+Thumbs.db

--- a/character.html
+++ b/character.html
@@ -55,8 +55,7 @@
         "lib0/environment": "./node_modules/lib0/environment.js",
         "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
         "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
-        "lib0/url": "./node_modules/lib0/url.js",
-        "lib0/webcrypto": "./node_modules/lib0/webcrypto.js"
+        "lib0/url": "./node_modules/lib0/url.js"
       }
     }
     </script>

--- a/index.html
+++ b/index.html
@@ -30,8 +30,6 @@
         "yjs": "./node_modules/yjs/dist/yjs.mjs",
         "y-websocket": "./node_modules/y-websocket/src/y-websocket.js",
         "y-indexeddb": "./node_modules/y-indexeddb/src/y-indexeddb.js",
-        "js-tiktoken": "./node_modules/js-tiktoken/dist/index.js",
-        "js-tiktoken/ranks/cl100k_base": "./node_modules/js-tiktoken/dist/ranks/cl100k_base.js",
         "y-protocols/sync": "./node_modules/y-protocols/sync.js",
         "y-protocols/auth": "./node_modules/y-protocols/auth.js",
         "y-protocols/awareness": "./node_modules/y-protocols/awareness.js",
@@ -56,8 +54,7 @@
         "lib0/environment": "./node_modules/lib0/environment.js",
         "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
         "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
-        "lib0/url": "./node_modules/lib0/url.js",
-        "lib0/webcrypto": "./node_modules/lib0/webcrypto.js"
+        "lib0/url": "./node_modules/lib0/url.js"
       }
     }
     </script>

--- a/settings.html
+++ b/settings.html
@@ -31,8 +31,6 @@
         "yjs": "./node_modules/yjs/dist/yjs.mjs",
         "y-websocket": "./node_modules/y-websocket/src/y-websocket.js",
         "y-indexeddb": "./node_modules/y-indexeddb/src/y-indexeddb.js",
-        "js-tiktoken": "./node_modules/js-tiktoken/dist/index.js",
-        "js-tiktoken/ranks/cl100k_base": "./node_modules/js-tiktoken/dist/ranks/cl100k_base.js",
         "y-protocols/sync": "./node_modules/y-protocols/sync.js",
         "y-protocols/auth": "./node_modules/y-protocols/auth.js",
         "y-protocols/awareness": "./node_modules/y-protocols/awareness.js",
@@ -57,8 +55,7 @@
         "lib0/environment": "./node_modules/lib0/environment.js",
         "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
         "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
-        "lib0/url": "./node_modules/lib0/url.js",
-        "lib0/webcrypto": "./node_modules/lib0/webcrypto.js"
+        "lib0/url": "./node_modules/lib0/url.js"
       }
     }
     </script>


### PR DESCRIPTION
Optimize Surge deployment by refining `.surgeignore` and removing unused `js-tiktoken` and `lib0/webcrypto` from import maps.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b70471d-b37c-4c0e-b5d1-d06d5743bc5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b70471d-b37c-4c0e-b5d1-d06d5743bc5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>