### PR TITLE
Fix import map for webcrypto

### DIFF
--- a/character.html
+++ b/character.html
@@ -83,7 +83,8 @@
         "lib0/environment": "./node_modules/lib0/environment.js",
         "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
         "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
-        "lib0/url": "./node_modules/lib0/url.js"
+        "lib0/url": "./node_modules/lib0/url.js",
+        "lib0/webcrypto": "./node_modules/lib0/webcrypto.js"
       }
     }
     </script>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,8 @@
         "lib0/environment": "./node_modules/lib0/environment.js",
         "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
         "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
-        "lib0/url": "./node_modules/lib0/url.js"
+        "lib0/url": "./node_modules/lib0/url.js",
+        "lib0/webcrypto": "./node_modules/lib0/webcrypto.js"
       }
     }
     </script>

--- a/settings.html
+++ b/settings.html
@@ -83,7 +83,8 @@
         "lib0/environment": "./node_modules/lib0/environment.js",
         "lib0/indexeddb": "./node_modules/lib0/indexeddb.js",
         "lib0/broadcastchannel": "./node_modules/lib0/broadcastchannel.js",
-        "lib0/url": "./node_modules/lib0/url.js"
+        "lib0/url": "./node_modules/lib0/url.js",
+        "lib0/webcrypto": "./node_modules/lib0/webcrypto.js"
       }
     }
     </script>


### PR DESCRIPTION
Restore `lib0/webcrypto` import map to fix module resolution errors.

The `lib0/webcrypto` import map was previously removed in commit `65c7a45` during a revert of performance optimizations. However, `lib0/random.js` (used by the YJS ecosystem) depends on `lib0/webcrypto`, leading to a "Failed to resolve module specifier" error. This PR re-adds the necessary mapping to resolve the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bf7fcbe-5374-4d82-aadc-75d32103b420">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5bf7fcbe-5374-4d82-aadc-75d32103b420">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>