### PR TITLE
Convert plain text notifications to toast messages

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -707,3 +707,62 @@ section {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
 }
+
+/* Toast Notifications */
+.notification {
+  position: fixed;
+  bottom: var(--space-xl);
+  right: var(--space-xl);
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border: var(--border-width) solid var(--color-border);
+  padding: var(--space-md) var(--space-lg);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-body);
+  max-width: 320px;
+  word-wrap: break-word;
+  z-index: 1000;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  animation: slideInFromRight 0.3s ease-out;
+}
+
+.notification--info {
+  border-left: 4px solid var(--color-accent);
+}
+
+.notification--success {
+  border-left: 4px solid #10b981;
+  background-color: #f0fdf4;
+}
+
+.notification--warning {
+  border-left: 4px solid #f59e0b;
+  background-color: #fffbeb;
+}
+
+.notification--error {
+  border-left: 4px solid #ef4444;
+  background-color: #fef2f2;
+}
+
+@keyframes slideInFromRight {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slideOutToRight {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+}

--- a/js/character-views.js
+++ b/js/character-views.js
@@ -1,5 +1,5 @@
 // Character Views - Pure Rendering Functions for Character Page
-import { getFormData } from './utils.js';
+import { getFormData, showNotification } from './utils.js';
 import {
   getCachedCharacterData,
   getFormDataForPage
@@ -67,21 +67,7 @@ export const toggleGenerateButton = (isAPIAvailable, hasContent = false) => {
   }
 };
 
-// Show notification message
-export const showNotification = (message, type = 'info') => {
-  const notification = document.createElement('div');
-  notification.className = `notification notification--${type}`;
-  notification.textContent = message;
-  
-  document.body.appendChild(notification);
-  
-  // Auto-remove after 3 seconds
-  setTimeout(() => {
-    if (notification.parentNode) {
-      notification.parentNode.removeChild(notification);
-    }
-  }, 3000);
-};
+// showNotification function moved to utils.js for shared use across all view modules
 
 
 

--- a/js/character.js
+++ b/js/character.js
@@ -15,11 +15,10 @@ import {
   renderCharacterForm,
   renderSummaries,
   toggleGenerateButton,
-  showNotification,
   renderCachedCharacterContent
 } from './character-views.js';
 
-import { getFormData } from './utils.js';
+import { getFormData, showNotification } from './utils.js';
 
 import { isAIEnabled } from './ai.js';
 import { summarize } from './summarization.js';

--- a/js/journal-views.js
+++ b/js/journal-views.js
@@ -1,5 +1,5 @@
 // Journal Views - Pure Rendering Functions for Journal Page
-import { parseMarkdown, formatDate, sortEntriesByDate, getFormData, formatAIPromptText } from './utils.js';
+import { parseMarkdown, formatDate, sortEntriesByDate, getFormData, formatAIPromptText, showNotification } from './utils.js';
 import {
   getCachedJournalEntries,
   getCachedCharacterData,
@@ -391,21 +391,7 @@ const updateEntryElement = (element, entry, onEdit, onDelete) => {
   if (deleteButton) deleteButton.onclick = () => onDelete(entry.id);
 };
 
-// Show notification message
-export const showNotification = (message, type = 'info') => {
-  const notification = document.createElement('div');
-  notification.className = `notification notification--${type}`;
-  notification.textContent = message;
-  
-  document.body.appendChild(notification);
-  
-  // Auto-remove after 3 seconds
-  setTimeout(() => {
-    if (notification.parentNode) {
-      notification.parentNode.removeChild(notification);
-    }
-  }, 3000);
-};
+// showNotification function moved to utils.js for shared use across all view modules
 
 
 

--- a/js/journal.js
+++ b/js/journal.js
@@ -18,12 +18,11 @@ import {
   renderEntries,
   createEntryForm,
   createEntryEditForm,
-  showNotification,
   renderAIPrompt,
   renderCachedJournalContent
 } from './journal-views.js';
 
-import { generateId, isValidEntry, formatDate, getFormData } from './utils.js';
+import { generateId, isValidEntry, formatDate, getFormData, showNotification } from './utils.js';
 
 import { generateQuestions } from './ai.js';
 import { hasContext as hasGoodContext } from './context.js';

--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -1,5 +1,5 @@
 // Settings Views - Pure Rendering Functions for Settings Page
-import { getFormData } from './utils.js';
+import { getFormData, showNotification } from './utils.js';
 import {
   getCachedSettings,
   getFormDataForPage
@@ -80,21 +80,7 @@ export const renderConnectionStatus = (isConnected, serverUrl) => {
   }
 };
 
-// Show notification message
-export const showNotification = (message, type = 'info') => {
-  const notification = document.createElement('div');
-  notification.className = `notification notification--${type}`;
-  notification.textContent = message;
-  
-  document.body.appendChild(notification);
-  
-  // Auto-remove after 3 seconds
-  setTimeout(() => {
-    if (notification.parentNode) {
-      notification.parentNode.removeChild(notification);
-    }
-  }, 3000);
-};
+// showNotification function moved to utils.js for shared use across all view modules
 
 
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -10,12 +10,11 @@ import {
 import {
   renderSettingsForm,
   renderConnectionStatus,
-  showNotification,
   renderCachedSettingsContent,
   renderAIPromptPreview
 } from './settings-views.js';
 
-import { getFormData } from './utils.js';
+import { getFormData, showNotification } from './utils.js';
 
 import { saveNavigationCache } from './navigation-cache.js';
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -155,3 +155,47 @@ export const getFormData = (form) => {
     return data;
   }
 };
+
+// Pure function to show toast notifications
+export const showNotification = (message, type = 'info', duration = 3000) => {
+  const notification = document.createElement('div');
+  notification.className = `notification notification--${type}`;
+  notification.textContent = message || '';
+  
+  // Add to body with proper positioning
+  document.body.appendChild(notification);
+  
+  // Stack notifications by adjusting bottom position
+  const existingNotifications = document.querySelectorAll('.notification');
+  if (existingNotifications.length > 1) {
+    let totalOffset = 0;
+    // Calculate offset based on existing notifications (excluding the current one)
+    Array.from(existingNotifications).slice(0, -1).forEach(existing => {
+      totalOffset += existing.offsetHeight + 12; // 12px gap between notifications
+    });
+    notification.style.bottom = `calc(var(--space-xl) + ${totalOffset}px)`;
+  }
+  
+  // Auto-remove after specified duration
+  setTimeout(() => {
+    if (notification.parentNode) {
+      notification.style.animation = 'slideOutToRight 0.3s ease-in forwards';
+      setTimeout(() => {
+        if (notification.parentNode) {
+          notification.parentNode.removeChild(notification);
+          // Reposition remaining notifications
+          repositionNotifications();
+        }
+      }, 300);
+    }
+  }, duration);
+};
+
+// Helper function to reposition remaining notifications after one is removed
+const repositionNotifications = () => {
+  const notifications = document.querySelectorAll('.notification');
+  notifications.forEach((notification, index) => {
+    const offset = index * (notification.offsetHeight + 12);
+    notification.style.bottom = `calc(var(--space-xl) + ${offset}px)`;
+  });
+};

--- a/test/settings-views.test.js
+++ b/test/settings-views.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { JSDOM } from 'jsdom';
 import * as SettingsViews from '../js/settings-views.js';
+import { showNotification } from '../js/utils.js';
 
 describe('Settings Views Module', function() {
   beforeEach(function() {
@@ -209,7 +210,7 @@ describe('Settings Views Module', function() {
     });
 
     it('should create and display notification', function() {
-      SettingsViews.showNotification('Test message');
+      showNotification('Test message');
 
       const notification = document.querySelector('.notification');
       expect(notification).to.exist;
@@ -218,7 +219,7 @@ describe('Settings Views Module', function() {
     });
 
     it('should create notification with custom type', function() {
-      SettingsViews.showNotification('Error message', 'error');
+      showNotification('Error message', 'error');
 
       const notification = document.querySelector('.notification');
       expect(notification).to.exist;
@@ -227,7 +228,7 @@ describe('Settings Views Module', function() {
     });
 
     it('should create notification with success type', function() {
-      SettingsViews.showNotification('Success message', 'success');
+      showNotification('Success message', 'success');
 
       const notification = document.querySelector('.notification');
       expect(notification).to.exist;
@@ -235,7 +236,7 @@ describe('Settings Views Module', function() {
     });
 
     it('should create notification with warning type', function() {
-      SettingsViews.showNotification('Warning message', 'warning');
+      showNotification('Warning message', 'warning');
 
       const notification = document.querySelector('.notification');
       expect(notification).to.exist;
@@ -245,7 +246,7 @@ describe('Settings Views Module', function() {
     it('should append notification to body', function() {
       const initialChildren = document.body.children.length;
       
-      SettingsViews.showNotification('Test message');
+      showNotification('Test message');
 
       expect(document.body.children.length).to.equal(initialChildren + 1);
       
@@ -254,7 +255,7 @@ describe('Settings Views Module', function() {
     });
 
     it('should auto-remove notification after timeout', function(done) {
-      SettingsViews.showNotification('Temporary message');
+      showNotification('Temporary message');
 
       const notification = document.querySelector('.notification');
       expect(notification).to.exist;
@@ -268,9 +269,9 @@ describe('Settings Views Module', function() {
     });
 
     it('should handle multiple notifications', function() {
-      SettingsViews.showNotification('First message', 'info');
-      SettingsViews.showNotification('Second message', 'error');
-      SettingsViews.showNotification('Third message', 'success');
+      showNotification('First message', 'info');
+      showNotification('Second message', 'error');
+      showNotification('Third message', 'success');
 
       const notifications = document.querySelectorAll('.notification');
       expect(notifications).to.have.length(3);
@@ -281,7 +282,7 @@ describe('Settings Views Module', function() {
     });
 
     it('should handle empty message', function() {
-      SettingsViews.showNotification('');
+      showNotification('');
 
       const notification = document.querySelector('.notification');
       expect(notification).to.exist;
@@ -289,7 +290,7 @@ describe('Settings Views Module', function() {
     });
 
     it('should handle null message', function() {
-      SettingsViews.showNotification(null);
+      showNotification(null);
 
       const notification = document.querySelector('.notification');
       expect(notification).to.exist;
@@ -473,7 +474,7 @@ describe('Settings Views Module', function() {
       }).to.not.throw();
 
       expect(() => {
-        SettingsViews.showNotification('test');
+        showNotification('test');
       }).to.not.throw();
     });
 


### PR DESCRIPTION
Convert plain text notifications to toast notifications and centralize the `showNotification` function in `utils.js` to improve UX and adhere to DRY principles.

The `showNotification` function was duplicated across multiple view modules, violating the DRY principle and architectural guidelines. This PR refactors it into a shared utility function in `utils.js` and enhances its presentation as a modern, dismissible toast notification, making it more noticeable on longer pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c1c0b07-39ca-4671-bd30-7dca766c430e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c1c0b07-39ca-4671-bd30-7dca766c430e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>