### PR TITLE
Fix session reflection goal sync and cache

### DIFF
--- a/js/journal-views.js
+++ b/js/journal-views.js
@@ -3,6 +3,7 @@ import { parseMarkdown, formatDate, sortEntriesByDate, getFormData, formatAIProm
 import {
   getCachedJournalEntries,
   getCachedCharacterData,
+  getCachedSessionQuestions,
   getFormDataForPage
 } from './navigation-cache.js';
 import { summarize } from './summarization.js';
@@ -523,9 +524,14 @@ export const renderCachedJournalContent = (elements) => {
     renderCharacterSummary(characterInfoContainer, cachedCharacter);
   }
   
-  // Show loading indicator for real-time content
+  // Show cached session questions if available, otherwise loading indicator
   if (aiPromptText) {
-    aiPromptText.innerHTML = formatAIPromptText('Loading writing prompt...');
+    const cachedQuestions = getCachedSessionQuestions();
+    if (cachedQuestions) {
+      showAIPromptQuestions(aiPromptText, cachedQuestions);
+    } else {
+      aiPromptText.innerHTML = formatAIPromptText('Loading writing prompt...');
+    }
   }
 };
 

--- a/js/journal.js
+++ b/js/journal.js
@@ -9,6 +9,7 @@ import {
   deleteEntry,
   onCharacterChange,
   onJournalChange,
+  onQuestionsChange,
   clearSessionQuestions
 } from './yjs.js';
 
@@ -89,6 +90,10 @@ export const initJournalPage = async (stateParam = null) => {
 
     onCharacterChange(state, () => {
       renderCharacterInfo(state);
+      renderAIPromptWithLogic(state);
+    });
+
+    onQuestionsChange(state, () => {
       renderAIPromptWithLogic(state);
     });
     

--- a/js/yjs.js
+++ b/js/yjs.js
@@ -219,6 +219,10 @@ export const onSummariesChange = (state, callback) => {
   getSummariesMap(state).observe(callback);
 };
 
+export const onQuestionsChange = (state, callback) => {
+  state.questionsMap.observe(callback);
+};
+
 // =============================================================================
 // SESSION QUESTIONS FUNCTIONS (Radically Simple)
 // =============================================================================

--- a/test/navigation-cache.test.js
+++ b/test/navigation-cache.test.js
@@ -10,6 +10,7 @@ import {
   getCachedCharacterData,
   getCachedSettings,
   getCachedFormData,
+  getCachedSessionQuestions,
   saveCurrentFormData,
   getFormDataForPage,
   getCacheAge,
@@ -108,6 +109,9 @@ describe('Navigation Cache', () => {
             const data = { 'sync-server-url': 'ws://localhost:1234', 'theme': 'dark' };
             return data[key];
           }
+        },
+        questionsMap: {
+          get: (key) => key === 'current' ? "1. What drives your character?\n2. What challenges do they face?" : null
         }
       };
       
@@ -124,7 +128,10 @@ describe('Navigation Cache', () => {
     });
     
     it('should include version and timestamp in cache', () => {
-      const mockYjsState = { journalArray: { toArray: () => [] } };
+      const mockYjsState = { 
+        journalArray: { toArray: () => [] },
+        questionsMap: { get: () => null }
+      };
       saveNavigationCache(mockYjsState);
       
       const cacheKey = 'dnd-journal-navigation-cache';
@@ -139,7 +146,10 @@ describe('Navigation Cache', () => {
   
   describe('Cache Validation', () => {
     it('should reject expired cache data', (done) => {
-      const mockYjsState = { journalArray: { toArray: () => [] } };
+      const mockYjsState = { 
+        journalArray: { toArray: () => [] },
+        questionsMap: { get: () => null }
+      };
       saveNavigationCache(mockYjsState);
       
       // Manually modify timestamp to simulate expired cache
@@ -158,7 +168,10 @@ describe('Navigation Cache', () => {
     });
     
     it('should reject incompatible cache versions', () => {
-      const mockYjsState = { journalArray: { toArray: () => [] } };
+      const mockYjsState = { 
+        journalArray: { toArray: () => [] },
+        questionsMap: { get: () => null }
+      };
       saveNavigationCache(mockYjsState);
       
       // Manually modify version
@@ -232,6 +245,33 @@ describe('Navigation Cache', () => {
       
       expect(cached['sync-server-url']).to.equal('ws://test:1234');
       expect(cached['theme']).to.equal('light');
+    });
+    
+    it('should extract session questions correctly', () => {
+      const sessionQuestions = "1. What motivates your character?\n2. What are they afraid of?";
+      const mockYjsState = {
+        questionsMap: {
+          get: (key) => key === 'current' ? sessionQuestions : null
+        }
+      };
+      
+      saveNavigationCache(mockYjsState);
+      const cached = getCachedSessionQuestions();
+      
+      expect(cached).to.equal(sessionQuestions);
+    });
+    
+    it('should handle missing session questions', () => {
+      const mockYjsState = {
+        questionsMap: {
+          get: () => null
+        }
+      };
+      
+      saveNavigationCache(mockYjsState);
+      const cached = getCachedSessionQuestions();
+      
+      expect(cached).to.be.null;
     });
   });
   


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add session reflection goals to navigation cache and ensure reactive updates to fix display issues on mobile.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The problem stemmed from session reflection goals (referred to as "session questions" in the code) not being included in the local navigation cache, unlike journal entries. This meant they weren't immediately available on page load, particularly impacting mobile devices where Yjs initialization might be slower. This PR addresses this by integrating session questions into the navigation cache for instant display and adding a Yjs observer for real-time updates across devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ccb102d-9ea0-4ddc-a921-c56c14367a87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ccb102d-9ea0-4ddc-a921-c56c14367a87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>