### PR TITLE
Add conditional refresh button for PWA

### DIFF
--- a/css/components/settings.css
+++ b/css/components/settings.css
@@ -86,6 +86,13 @@
   text-align: center;
 }
 
+/* PWA Refresh Section */
+.pwa-refresh-section {
+  margin-top: var(--space-lg);
+  padding-top: var(--space-lg);
+  border-top: var(--border-width) solid var(--color-border-light);
+}
+
 .btn-large {
   padding: var(--space-md) var(--space-xl);
   font-size: var(--font-size-lg);

--- a/css/components/settings.css
+++ b/css/components/settings.css
@@ -86,11 +86,16 @@
   text-align: center;
 }
 
-/* PWA Refresh Section */
-.pwa-refresh-section {
-  margin-top: var(--space-lg);
-  padding-top: var(--space-lg);
-  border-top: var(--border-width) solid var(--color-border-light);
+/* PWA Refresh Button */
+[data-pwa-only] {
+  margin-top: var(--space-md);
+}
+
+/* Show PWA-only elements in standalone mode */
+@media (display-mode: standalone) {
+  [data-pwa-only] {
+    display: inline-block !important;
+  }
 }
 
 .btn-large {

--- a/js/settings.js
+++ b/js/settings.js
@@ -14,7 +14,7 @@ import {
   renderAIPromptPreview
 } from './settings-views.js';
 
-import { getFormData, showNotification, isStandaloneMode } from './utils.js';
+import { getFormData, showNotification } from './utils.js';
 
 import { saveNavigationCache } from './navigation-cache.js';
 
@@ -60,9 +60,6 @@ export const initSettingsPage = async (stateParam = null) => {
     
     // Set up form handling after initial render (ensures DOM elements exist)
     setupFormHandlers();
-    
-    // Set up PWA refresh button visibility and handling
-    setupPWARefreshButton();
     
     // Save cache on page unload
     window.addEventListener('beforeunload', () => {
@@ -141,10 +138,7 @@ const setupFormHandlers = () => {
   
   const refreshAppButton = document.getElementById('refresh-app');
   if (refreshAppButton && !refreshAppButton.hasAttribute('data-handler-attached')) {
-    refreshAppButton.addEventListener('click', (e) => {
-      e.preventDefault();
-      refreshApp();
-    });
+    refreshAppButton.addEventListener('click', () => window.location.reload());
     refreshAppButton.setAttribute('data-handler-attached', 'true');
   }
 
@@ -350,33 +344,7 @@ export const clearAllSummariesHandler = () => {
   }
 };
 
-// Set up PWA refresh button visibility and handling
-const setupPWARefreshButton = () => {
-  try {
-    const refreshSection = document.getElementById('pwa-refresh-section');
-    if (refreshSection) {
-      // Show refresh button only in standalone mode (PWA)
-      if (isStandaloneMode()) {
-        refreshSection.style.display = 'block';
-      } else {
-        refreshSection.style.display = 'none';
-      }
-    }
-  } catch (error) {
-    console.error('Failed to setup PWA refresh button:', error);
-  }
-};
 
-// Refresh app functionality
-export const refreshApp = () => {
-  try {
-    // Reload the current page to refresh the app
-    window.location.reload();
-  } catch (error) {
-    console.error('Failed to refresh app:', error);
-    showNotification('Error refreshing app', 'error');
-  }
-};
 
 
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -14,7 +14,7 @@ import {
   renderAIPromptPreview
 } from './settings-views.js';
 
-import { getFormData, showNotification } from './utils.js';
+import { getFormData, showNotification, isStandaloneMode } from './utils.js';
 
 import { saveNavigationCache } from './navigation-cache.js';
 
@@ -60,6 +60,9 @@ export const initSettingsPage = async (stateParam = null) => {
     
     // Set up form handling after initial render (ensures DOM elements exist)
     setupFormHandlers();
+    
+    // Set up PWA refresh button visibility and handling
+    setupPWARefreshButton();
     
     // Save cache on page unload
     window.addEventListener('beforeunload', () => {
@@ -134,6 +137,15 @@ const setupFormHandlers = () => {
       clearAllSummariesHandler();
     });
     clearSummariesButton.setAttribute('data-handler-attached', 'true');
+  }
+  
+  const refreshAppButton = document.getElementById('refresh-app');
+  if (refreshAppButton && !refreshAppButton.hasAttribute('data-handler-attached')) {
+    refreshAppButton.addEventListener('click', (e) => {
+      e.preventDefault();
+      refreshApp();
+    });
+    refreshAppButton.setAttribute('data-handler-attached', 'true');
   }
 
   // Form handler setup (can return early if form not found)
@@ -335,6 +347,34 @@ export const clearAllSummariesHandler = () => {
   } catch (error) {
     console.error('Failed to clear summaries:', error);
     showNotification('Error clearing summaries', 'error');
+  }
+};
+
+// Set up PWA refresh button visibility and handling
+const setupPWARefreshButton = () => {
+  try {
+    const refreshSection = document.getElementById('pwa-refresh-section');
+    if (refreshSection) {
+      // Show refresh button only in standalone mode (PWA)
+      if (isStandaloneMode()) {
+        refreshSection.style.display = 'block';
+      } else {
+        refreshSection.style.display = 'none';
+      }
+    }
+  } catch (error) {
+    console.error('Failed to setup PWA refresh button:', error);
+  }
+};
+
+// Refresh app functionality
+export const refreshApp = () => {
+  try {
+    // Reload the current page to refresh the app
+    window.location.reload();
+  } catch (error) {
+    console.error('Failed to refresh app:', error);
+    showNotification('Error refreshing app', 'error');
   }
 };
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -213,3 +213,9 @@ const repositionNotifications = () => {
     notification.style.bottom = `calc(var(--space-xl) + ${offset}px)`;
   });
 };
+
+// Pure function to check if app is in PWA standalone mode
+export const isStandaloneMode = () => {
+  // Check if running in standalone display mode (PWA)
+  return window.matchMedia && window.matchMedia('(display-mode: standalone)').matches;
+};

--- a/js/utils.js
+++ b/js/utils.js
@@ -214,8 +214,4 @@ const repositionNotifications = () => {
   });
 };
 
-// Pure function to check if app is in PWA standalone mode
-export const isStandaloneMode = () => {
-  // Check if running in standalone display mode (PWA)
-  return window.matchMedia && window.matchMedia('(display-mode: standalone)').matches;
-};
+

--- a/settings.html
+++ b/settings.html
@@ -257,12 +257,9 @@
                     <p class="form-help">Saves both sync and AI configuration settings</p>
                     
                     <!-- PWA Refresh Button - Only visible in standalone mode -->
-                    <div id="pwa-refresh-section" class="pwa-refresh-section" style="display: none;">
-                        <button id="refresh-app" type="button" class="btn btn-secondary">
-                            Refresh App
-                        </button>
-                        <p class="form-help">Refresh the app to ensure you have the latest version</p>
-                    </div>
+                    <button id="refresh-app" type="button" class="btn btn-secondary" style="display: none;" data-pwa-only>
+                        Refresh App
+                    </button>
                 </div>
             </form>
         </div>

--- a/settings.html
+++ b/settings.html
@@ -255,6 +255,14 @@
                         Save All Settings
                     </button>
                     <p class="form-help">Saves both sync and AI configuration settings</p>
+                    
+                    <!-- PWA Refresh Button - Only visible in standalone mode -->
+                    <div id="pwa-refresh-section" class="pwa-refresh-section" style="display: none;">
+                        <button id="refresh-app" type="button" class="btn btn-secondary">
+                            Refresh App
+                        </button>
+                        <p class="form-help">Refresh the app to ensure you have the latest version</p>
+                    </div>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
Add a refresh button to the settings page, visible only in PWA standalone mode, to allow users to easily update the app.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef6d16f8-850e-494e-9130-f0e63ce28abf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef6d16f8-850e-494e-9130-f0e63ce28abf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>