### PR TITLE
Optimize summary function cache checks

### DIFF
--- a/js/journal-views.js
+++ b/js/journal-views.js
@@ -92,30 +92,9 @@ export const createEntrySummarySection = (entry) => {
   const summarySection = document.createElement('div');
   summarySection.className = 'entry-summary-section';
   
-  let existingSummary = null;
-  
-  // Try to get existing summary (handle case where Y.js isn't initialized)
-  try {
-    const state = getYjsState();
-    const summaryKey = `entry:${entry.id}`;
-    existingSummary = getSummary(state, summaryKey);
-  } catch (error) {
-    // Y.js not initialized - fall back to full content display
-    const fullContentDiv = document.createElement('div');
-    fullContentDiv.className = 'entry-content';
-    fullContentDiv.innerHTML = parseMarkdown(entry.content);
-    summarySection.appendChild(fullContentDiv);
-    return summarySection;
-  }
-  
-  if (existingSummary) {
-    // Show summary with collapsible full content
-    summarySection.appendChild(createSummaryDisplay(existingSummary, entry));
-  } else {
-    // Show full content by default if no summary, with async summary generation
-    summarySection.appendChild(createSummaryDisplay(null, entry));
-    generateSummaryAsync(entry, summarySection);
-  }
+  // Always start with full content display and let summarize() handle cache checking
+  summarySection.appendChild(createSummaryDisplay(null, entry));
+  generateSummaryAsync(entry, summarySection);
   
   return summarySection;
 };

--- a/js/journal-views.js
+++ b/js/journal-views.js
@@ -7,7 +7,7 @@ import {
   getFormDataForPage
 } from './navigation-cache.js';
 import { summarize } from './summarization.js';
-import { getYjsState, getSummary } from './yjs.js';
+import { getYjsState } from './yjs.js';
 
 // Create journal entry form
 export const createEntryForm = (options = {}) => {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove redundant cache check in `journal-views.js` because `summarize()` already handles caching.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `summarize()` function internally checks if a summary exists in the state before generating a new one. The `journal-views.js` file was performing this check again before calling `summarize()`, leading to duplicated logic. This change simplifies the code by relying solely on `summarize()`'s internal caching mechanism, improving maintainability and adhering to the Radical Simplicity Principle.

---
<a href="https://cursor.com/background-agent?bcId=bc-9304bea4-7912-472f-8cb0-f3fb7be9721f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9304bea4-7912-472f-8cb0-f3fb7be9721f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>