### PR TITLE
Fix ai prompt button and add word count

### DIFF
--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -63,6 +63,26 @@ export const renderSettingsForm = (formOrSettings, settings = null) => {
   }
 };
 
+// Pure helper to update Show AI Prompt button state based on live input values
+export const updateShowAIPromptButtonState = (apiKeyValue, aiEnabledValue) => {
+  const showPromptButton = document.getElementById('show-ai-prompt');
+  if (!showPromptButton) return;
+
+  const hasApiKey = Boolean(apiKeyValue && apiKeyValue.trim().length > 0);
+  const aiEnabled = Boolean(aiEnabledValue);
+  showPromptButton.disabled = !hasApiKey || !aiEnabled;
+
+  if (!hasApiKey && !aiEnabled) {
+    showPromptButton.title = 'Requires OpenAI API Key and AI Features to be enabled';
+  } else if (!hasApiKey) {
+    showPromptButton.title = 'Requires OpenAI API Key';
+  } else if (!aiEnabled) {
+    showPromptButton.title = 'Requires AI Features to be enabled';
+  } else {
+    showPromptButton.title = 'Show current AI prompt configuration';
+  }
+};
+
 // Update connection status display
 export const renderConnectionStatus = (isConnected, serverUrl) => {
   const statusElement = document.getElementById('connection-status');
@@ -118,13 +138,52 @@ export const renderAIPromptPreview = (aiEnabled, messages = null) => {
       </div>
     `;
   } else {
-    // Show the exact messages sent to OpenAI
-    const content = messages.map(msg => `
-      <div class="${msg.role === 'system' ? 'system-prompt' : 'user-prompt'}">
-        <h4>${msg.role === 'system' ? 'System' : 'User'}</h4>
-        <div>${msg.content}</div>
-      </div>
-    `).join('');
+    // Compute word counts for system and user prompts
+    const systemMsg = messages.find(m => m.role === 'system');
+    const userMsg = messages.find(m => m.role === 'user');
+    let systemWords = 0;
+    let userWords = 0;
+    try {
+      // Lazy import to avoid circular deps in tests
+      // and keep this function pure w.r.t. state
+      // getWordCount is a pure function
+      // eslint-disable-next-line no-undef
+      
+    } catch (e) {}
+
+    // Use direct import since this is a module context
+    // Importing at top would be fine but keep footprint minimal
+    // Note: In browsers, static import is preferred. Here we keep compatibility.
+
+    // Fallback if dynamic import fails
+    const calculateCounts = (gwc) => {
+      const getWordCount = gwc || ((t) => (t || '').trim().split(/\s+/).filter(w => w.length > 0).length);
+      systemWords = getWordCount(systemMsg?.content || '');
+      userWords = getWordCount(userMsg?.content || '');
+    };
+
+    try {
+      // Attempt dynamic import
+      // This avoids adding a hard dependency cycle in some test runners
+      // and still uses the shared util when available
+      // @ts-ignore
+      import('./utils.js').then(mod => calculateCounts(mod.getWordCount)).catch(() => calculateCounts(null));
+    } catch (e) {
+      calculateCounts(null);
+    }
+
+    const totalWords = () => systemWords + userWords;
+
+    // Show the exact messages sent to OpenAI with counts header
+    const content = `
+      <div class="token-count">System: ${systemWords} • User: ${userWords} • Total: ${totalWords()} words</div>
+      ${messages.map(msg => `
+        <div class="${msg.role === 'system' ? 'system-prompt' : 'user-prompt'}">
+          <h4>${msg.role === 'system' ? 'System' : 'User'}</h4>
+          <div>${msg.content}</div>
+        </div>
+      `).join('')}
+    `;
     
     promptContentElement.innerHTML = content;
   }


### PR DESCRIPTION
Fixes the "Show current AI prompt" button and adds word count to the AI prompt preview.

The button now works reliably, updates its enabled state live with API key/AI enabled changes, and ensures Yjs is initialized before use. Word counts for system, user, and total words are now displayed in the preview.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3b17790-4b98-4cf1-a353-1dbc42dd280c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3b17790-4b98-4cf1-a353-1dbc42dd280c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

