### PR TITLE
Add word count to settings page

### DIFF
--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -1,5 +1,5 @@
 // Settings Views - Pure Rendering Functions for Settings Page
-import { getFormData, showNotification } from './utils.js';
+import { getFormData, showNotification, getWordCount } from './utils.js';
 import {
   getCachedSettings,
   getFormDataForPage
@@ -118,15 +118,20 @@ export const renderAIPromptPreview = (aiEnabled, messages = null) => {
       </div>
     `;
   } else {
-    // Show the exact messages sent to OpenAI
+    // Show the exact messages sent to OpenAI with word count summary
+    const totalWords = Array.isArray(messages)
+      ? messages.reduce((sum, msg) => sum + getWordCount(String(msg && msg.content ? msg.content : '')), 0)
+      : 0;
+
     const content = messages.map(msg => `
       <div class="${msg.role === 'system' ? 'system-prompt' : 'user-prompt'}">
         <h4>${msg.role === 'system' ? 'System' : 'User'}</h4>
         <div>${msg.content}</div>
       </div>
     `).join('');
-    
-    promptContentElement.innerHTML = content;
+
+    const header = `<div class="token-count">Word count: ${totalWords}</div>`;
+    promptContentElement.innerHTML = header + content;
   }
   
   promptPreviewElement.style.display = 'block';


### PR DESCRIPTION
Add word count display to the AI prompt preview on the settings page.

---
<a href="https://cursor.com/background-agent?bcId=bc-063b05e2-5b4a-4677-97b0-90b1893c8575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-063b05e2-5b4a-4677-97b0-90b1893c8575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

