### PR TITLE
Serve static html on port 80

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -10,22 +10,13 @@
 import { WebSocketServer } from 'ws';
 import { setupWSConnection } from 'y-websocket/bin/utils';
 import { LeveldbPersistence } from 'y-leveldb';
-import { existsSync, readdirSync, mkdirSync, writeFileSync, unlinkSync, createReadStream } from 'fs';
-import { resolve, dirname, extname } from 'path';
-import http from 'http';
-import { fileURLToPath } from 'url';
+import { existsSync, readdirSync, mkdirSync, writeFileSync, unlinkSync } from 'fs';
+import { resolve } from 'path';
 import * as Y from 'yjs';
 
 const PORT = process.env.PORT || process.argv[2] || 1234;
 const HOST = process.env.HOST || process.argv[3] || '0.0.0.0';
 const DATA_DIR = process.env.DATA_DIR || './data';
-const HTTP_PORT = Number(process.env.HTTP_PORT || 80);
-const HTTP_HOST = process.env.HTTP_HOST || '0.0.0.0';
-
-// Resolve static root to project root (parent of this server directory)
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const STATIC_ROOT = resolve(__dirname, '..');
 
 // Log startup information
 console.log(`🚀 D&D Journal Server: ws://${HOST}:${PORT}`);
@@ -85,76 +76,6 @@ wss.on('connection', (ws, req) => {
 wss.on('error', (error) => {
   console.error('🚨 WebSocket server error:', error.message);
 });
-
-// Minimal static file server (no frameworks)
-const contentTypeByExt = (filePath) => {
-  const ext = extname(filePath).toLowerCase();
-  if (ext === '.html') return 'text/html; charset=utf-8';
-  if (ext === '.js') return 'application/javascript; charset=utf-8';
-  if (ext === '.css') return 'text/css; charset=utf-8';
-  if (ext === '.json') return 'application/json; charset=utf-8';
-  if (ext === '.svg') return 'image/svg+xml; charset=utf-8';
-  if (ext === '.png') return 'image/png';
-  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
-  if (ext === '.ico') return 'image/x-icon';
-  return 'application/octet-stream';
-};
-
-const sendNotFound = (res) => {
-  res.statusCode = 404;
-  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
-  res.end('Not Found');
-};
-
-const sendServerError = (res) => {
-  res.statusCode = 500;
-  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
-  res.end('Internal Server Error');
-};
-
-const httpServer = http.createServer((req, res) => {
-  try {
-    const url = req.url || '/';
-    const rawPath = decodeURIComponent(url.split('?')[0]);
-    const requestedPath = rawPath.endsWith('/') ? rawPath + 'index.html' : rawPath;
-    const absolutePath = resolve(STATIC_ROOT, '.' + requestedPath);
-
-    // Prevent path traversal outside STATIC_ROOT
-    if (!absolutePath.startsWith(STATIC_ROOT)) {
-      return sendNotFound(res);
-    }
-
-    // Basic existence check and stream response
-    if (!existsSync(absolutePath)) {
-      return sendNotFound(res);
-    }
-
-    res.statusCode = 200;
-    res.setHeader('Content-Type', contentTypeByExt(absolutePath));
-    const stream = createReadStream(absolutePath);
-    stream.on('error', () => sendServerError(res));
-    stream.pipe(res);
-  } catch (_e) {
-    return sendServerError(res);
-  }
-});
-
-const startHttpServer = (portToUse) => {
-  httpServer.listen(portToUse, HTTP_HOST, () => {
-    console.log(`🌐 HTTP static server: http://${HTTP_HOST}:${portToUse} (root: ${STATIC_ROOT})`);
-  });
-
-  httpServer.on('error', (err) => {
-    if ((err.code === 'EACCES' || err.code === 'EADDRINUSE') && portToUse !== 8080) {
-      console.warn(`⚠️  HTTP server on port ${portToUse} failed (${err.code}). Falling back to 8080.`);
-      startHttpServer(8080);
-    } else {
-      console.error('🚨 HTTP server error:', err.message);
-    }
-  });
-};
-
-startHttpServer(HTTP_PORT);
 
 
 process.on('SIGINT', () => {

--- a/server/server.js
+++ b/server/server.js
@@ -10,13 +10,22 @@
 import { WebSocketServer } from 'ws';
 import { setupWSConnection } from 'y-websocket/bin/utils';
 import { LeveldbPersistence } from 'y-leveldb';
-import { existsSync, readdirSync, mkdirSync, writeFileSync, unlinkSync } from 'fs';
-import { resolve } from 'path';
+import { existsSync, readdirSync, mkdirSync, writeFileSync, unlinkSync, createReadStream } from 'fs';
+import { resolve, dirname, extname } from 'path';
+import http from 'http';
+import { fileURLToPath } from 'url';
 import * as Y from 'yjs';
 
 const PORT = process.env.PORT || process.argv[2] || 1234;
 const HOST = process.env.HOST || process.argv[3] || '0.0.0.0';
 const DATA_DIR = process.env.DATA_DIR || './data';
+const HTTP_PORT = Number(process.env.HTTP_PORT || 80);
+const HTTP_HOST = process.env.HTTP_HOST || '0.0.0.0';
+
+// Resolve static root to project root (parent of this server directory)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const STATIC_ROOT = resolve(__dirname, '..');
 
 // Log startup information
 console.log(`🚀 D&D Journal Server: ws://${HOST}:${PORT}`);
@@ -77,6 +86,75 @@ wss.on('error', (error) => {
   console.error('🚨 WebSocket server error:', error.message);
 });
 
+// Minimal static file server (no frameworks)
+const contentTypeByExt = (filePath) => {
+  const ext = extname(filePath).toLowerCase();
+  if (ext === '.html') return 'text/html; charset=utf-8';
+  if (ext === '.js') return 'application/javascript; charset=utf-8';
+  if (ext === '.css') return 'text/css; charset=utf-8';
+  if (ext === '.json') return 'application/json; charset=utf-8';
+  if (ext === '.svg') return 'image/svg+xml; charset=utf-8';
+  if (ext === '.png') return 'image/png';
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
+  if (ext === '.ico') return 'image/x-icon';
+  return 'application/octet-stream';
+};
+
+const sendNotFound = (res) => {
+  res.statusCode = 404;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.end('Not Found');
+};
+
+const sendServerError = (res) => {
+  res.statusCode = 500;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.end('Internal Server Error');
+};
+
+const httpServer = http.createServer((req, res) => {
+  try {
+    const url = req.url || '/';
+    const rawPath = decodeURIComponent(url.split('?')[0]);
+    const requestedPath = rawPath.endsWith('/') ? rawPath + 'index.html' : rawPath;
+    const absolutePath = resolve(STATIC_ROOT, '.' + requestedPath);
+
+    // Prevent path traversal outside STATIC_ROOT
+    if (!absolutePath.startsWith(STATIC_ROOT)) {
+      return sendNotFound(res);
+    }
+
+    // Basic existence check and stream response
+    if (!existsSync(absolutePath)) {
+      return sendNotFound(res);
+    }
+
+    res.statusCode = 200;
+    res.setHeader('Content-Type', contentTypeByExt(absolutePath));
+    const stream = createReadStream(absolutePath);
+    stream.on('error', () => sendServerError(res));
+    stream.pipe(res);
+  } catch (_e) {
+    return sendServerError(res);
+  }
+});
+
+const startHttpServer = (portToUse) => {
+  httpServer.listen(portToUse, HTTP_HOST, () => {
+    console.log(`🌐 HTTP static server: http://${HTTP_HOST}:${portToUse} (root: ${STATIC_ROOT})`);
+  });
+
+  httpServer.on('error', (err) => {
+    if ((err.code === 'EACCES' || err.code === 'EADDRINUSE') && portToUse !== 8080) {
+      console.warn(`⚠️  HTTP server on port ${portToUse} failed (${err.code}). Falling back to 8080.`);
+      startHttpServer(8080);
+    } else {
+      console.error('🚨 HTTP server error:', err.message);
+    }
+  });
+};
+
+startHttpServer(HTTP_PORT);
 
 
 process.on('SIGINT', () => {


### PR DESCRIPTION
Add an HTTP static server to `server/server.js` to serve static files from the project root on port 80, with a fallback to port 8080.

---
<a href="https://cursor.com/background-agent?bcId=bc-34fbbbc7-2869-440e-a266-62f67ed7b561">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34fbbbc7-2869-440e-a266-62f67ed7b561">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

