### PR TITLE
Fix ssh agent passphrase error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,9 +34,22 @@ jobs:
           bash scripts/generate-version.sh
 
       - name: Start SSH agent and add key
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.PI_SSH_PRIVATE_KEY }}
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.PI_SSH_PRIVATE_KEY }}
+          SSH_PASSPHRASE: ${{ secrets.PI_SSH_PASSPHRASE }}
+        run: |
+          eval "$(ssh-agent -s)"
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
+          if [ -n "$SSH_PASSPHRASE" ]; then
+            echo "echo \"$SSH_PASSPHRASE\"" > /tmp/ssh_askpass.sh
+            chmod 700 /tmp/ssh_askpass.sh
+            export SSH_ASKPASS=/tmp/ssh_askpass.sh
+            export SSH_ASKPASS_REQUIRE=force
+            export DISPLAY=:0
+          fi
+          echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add -
+          if [ -f /tmp/ssh_askpass.sh ]; then rm -f /tmp/ssh_askpass.sh; unset SSH_ASKPASS SSH_ASKPASS_REQUIRE; fi
 
       - name: Add Pi host to known_hosts
         run: |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Required GitHub Secrets:
 - `PI_REPO_PATH`: Absolute path to bare repo (e.g. `/home/pi/repos/dnd-journal.git`)
 - `PI_SSH_PRIVATE_KEY`: Private key for CI push
 - `PI_SSH_PORT` (optional): SSH port, defaults to 22
+ - `PI_SSH_PASSPHRASE` (optional): Passphrase for the private key if encrypted
 
 Version info:
 - `scripts/generate-version.sh` prints commit/run metadata for logs or optional artifacts


### PR DESCRIPTION
Replace `webfactory/ssh-agent` with a manual setup to support passphrase-protected SSH keys.

The `webfactory/ssh-agent` action failed when attempting to add a private key that required a passphrase, as it would hang waiting for interactive input. This change implements a manual `ssh-agent` setup that leverages `SSH_ASKPASS` to provide the passphrase non-interactively, resolving the deployment script's failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a7b64bb-a015-42e8-934c-c236f7fa4144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a7b64bb-a015-42e8-934c-c236f7fa4144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

