### PR TITLE
Disable deploy github workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy to Raspberry Pi
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Remove the `push` trigger from `deploy.yml` to disable automatic deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9f879ea-d266-4a36-a254-43b53db5494d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9f879ea-d266-4a36-a254-43b53db5494d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

