### PR TITLE
Investigate and fix yjs module resolution error

### DIFF
--- a/character.html
+++ b/character.html
@@ -23,34 +23,6 @@
     <link rel="stylesheet" href="css/components/tabs.css">
     <link rel="stylesheet" href="css/components/character-form.css">
     
-    <!-- Module Preloads for Performance -->
-    <!-- Core application modules for character page -->
-    <link rel="modulepreload" href="js/character.js">
-    <link rel="modulepreload" href="js/yjs.js">
-    <link rel="modulepreload" href="js/character-views.js">
-    <link rel="modulepreload" href="js/utils.js">
-    <link rel="modulepreload" href="js/navigation-cache.js">
-    
-    <!-- Secondary modules -->
-    <link rel="modulepreload" href="js/ai.js">
-    <link rel="modulepreload" href="js/summarization.js">
-    
-    <!-- YJS and lib0 dependencies from node_modules -->
-    <link rel="modulepreload" href="./node_modules/yjs/dist/yjs.mjs">
-    <link rel="modulepreload" href="./node_modules/y-websocket/src/y-websocket.js">
-    <link rel="modulepreload" href="./node_modules/y-indexeddb/src/y-indexeddb.js">
-    <link rel="modulepreload" href="./node_modules/y-protocols/sync.js">
-    <link rel="modulepreload" href="./node_modules/y-protocols/awareness.js">
-    <link rel="modulepreload" href="./node_modules/lib0/observable.js">
-    <link rel="modulepreload" href="./node_modules/lib0/array.js">
-    <link rel="modulepreload" href="./node_modules/lib0/map.js">
-    <link rel="modulepreload" href="./node_modules/lib0/encoding.js">
-    <link rel="modulepreload" href="./node_modules/lib0/decoding.js">
-    <link rel="modulepreload" href="./node_modules/lib0/random.js">
-    <link rel="modulepreload" href="./node_modules/lib0/environment.js">
-    <link rel="modulepreload" href="./node_modules/lib0/indexeddb.js">
-    <link rel="modulepreload" href="./node_modules/lib0/broadcastchannel.js">
-    
     <!-- Import Map for YJS modules -->
     <script type="importmap">
     {
@@ -87,6 +59,36 @@
       }
     }
     </script>
+    
+    <!-- Module Preloads for Performance -->
+    <!-- Core application modules for character page -->
+    <link rel="modulepreload" href="js/character.js">
+    <link rel="modulepreload" href="js/yjs.js">
+    <link rel="modulepreload" href="js/character-views.js">
+    <link rel="modulepreload" href="js/utils.js">
+    <link rel="modulepreload" href="js/navigation-cache.js">
+    
+    <!-- Secondary modules -->
+    <link rel="modulepreload" href="js/ai.js">
+    <link rel="modulepreload" href="js/summarization.js">
+    
+    <!-- YJS and lib0 dependencies from node_modules -->
+    <link rel="modulepreload" href="./node_modules/yjs/dist/yjs.mjs">
+    <link rel="modulepreload" href="./node_modules/y-websocket/src/y-websocket.js">
+    <link rel="modulepreload" href="./node_modules/y-indexeddb/src/y-indexeddb.js">
+    <link rel="modulepreload" href="./node_modules/y-protocols/sync.js">
+    <link rel="modulepreload" href="./node_modules/y-protocols/awareness.js">
+    <link rel="modulepreload" href="./node_modules/lib0/observable.js">
+    <link rel="modulepreload" href="./node_modules/lib0/array.js">
+    <link rel="modulepreload" href="./node_modules/lib0/map.js">
+    <link rel="modulepreload" href="./node_modules/lib0/encoding.js">
+    <link rel="modulepreload" href="./node_modules/lib0/decoding.js">
+    <link rel="modulepreload" href="./node_modules/lib0/random.js">
+    <link rel="modulepreload" href="./node_modules/lib0/environment.js">
+    <link rel="modulepreload" href="./node_modules/lib0/indexeddb.js">
+    <link rel="modulepreload" href="./node_modules/lib0/broadcastchannel.js">
+    
+    
 </head>
 <body>
     <header class="tabs">

--- a/index.html
+++ b/index.html
@@ -23,35 +23,6 @@
     <link rel="stylesheet" href="css/components/tabs.css">
     <link rel="stylesheet" href="css/components/ai-prompt.css">
     
-    <!-- Module Preloads for Performance -->
-    <!-- Core application modules -->
-    <link rel="modulepreload" href="js/journal.js">
-    <link rel="modulepreload" href="js/yjs.js">
-    <link rel="modulepreload" href="js/journal-views.js">
-    <link rel="modulepreload" href="js/utils.js">
-    <link rel="modulepreload" href="js/navigation-cache.js">
-    
-    <!-- Secondary modules -->
-    <link rel="modulepreload" href="js/ai.js">
-    <link rel="modulepreload" href="js/context.js">
-    <link rel="modulepreload" href="js/summarization.js">
-    
-    <!-- YJS and lib0 dependencies from node_modules -->
-    <link rel="modulepreload" href="./node_modules/yjs/dist/yjs.mjs">
-    <link rel="modulepreload" href="./node_modules/y-websocket/src/y-websocket.js">
-    <link rel="modulepreload" href="./node_modules/y-indexeddb/src/y-indexeddb.js">
-    <link rel="modulepreload" href="./node_modules/y-protocols/sync.js">
-    <link rel="modulepreload" href="./node_modules/y-protocols/awareness.js">
-    <link rel="modulepreload" href="./node_modules/lib0/observable.js">
-    <link rel="modulepreload" href="./node_modules/lib0/array.js">
-    <link rel="modulepreload" href="./node_modules/lib0/map.js">
-    <link rel="modulepreload" href="./node_modules/lib0/encoding.js">
-    <link rel="modulepreload" href="./node_modules/lib0/decoding.js">
-    <link rel="modulepreload" href="./node_modules/lib0/random.js">
-    <link rel="modulepreload" href="./node_modules/lib0/environment.js">
-    <link rel="modulepreload" href="./node_modules/lib0/indexeddb.js">
-    <link rel="modulepreload" href="./node_modules/lib0/broadcastchannel.js">
-
     <!-- Import Map for YJS modules -->
     <script type="importmap">
     {
@@ -88,6 +59,37 @@
       }
     }
     </script>
+    
+    <!-- Module Preloads for Performance -->
+    <!-- Core application modules -->
+    <link rel="modulepreload" href="js/journal.js">
+    <link rel="modulepreload" href="js/yjs.js">
+    <link rel="modulepreload" href="js/journal-views.js">
+    <link rel="modulepreload" href="js/utils.js">
+    <link rel="modulepreload" href="js/navigation-cache.js">
+    
+    <!-- Secondary modules -->
+    <link rel="modulepreload" href="js/ai.js">
+    <link rel="modulepreload" href="js/context.js">
+    <link rel="modulepreload" href="js/summarization.js">
+    
+    <!-- YJS and lib0 dependencies from node_modules -->
+    <link rel="modulepreload" href="./node_modules/yjs/dist/yjs.mjs">
+    <link rel="modulepreload" href="./node_modules/y-websocket/src/y-websocket.js">
+    <link rel="modulepreload" href="./node_modules/y-indexeddb/src/y-indexeddb.js">
+    <link rel="modulepreload" href="./node_modules/y-protocols/sync.js">
+    <link rel="modulepreload" href="./node_modules/y-protocols/awareness.js">
+    <link rel="modulepreload" href="./node_modules/lib0/observable.js">
+    <link rel="modulepreload" href="./node_modules/lib0/array.js">
+    <link rel="modulepreload" href="./node_modules/lib0/map.js">
+    <link rel="modulepreload" href="./node_modules/lib0/encoding.js">
+    <link rel="modulepreload" href="./node_modules/lib0/decoding.js">
+    <link rel="modulepreload" href="./node_modules/lib0/random.js">
+    <link rel="modulepreload" href="./node_modules/lib0/environment.js">
+    <link rel="modulepreload" href="./node_modules/lib0/indexeddb.js">
+    <link rel="modulepreload" href="./node_modules/lib0/broadcastchannel.js">
+
+    
 
 </head>
 <body>

--- a/settings.html
+++ b/settings.html
@@ -26,36 +26,6 @@
     <link rel="stylesheet" href="css/components/sync-status.css">
     <link rel="stylesheet" href="css/components/modal.css">
     
-    <!-- Module Preloads for Performance -->
-    <!-- Core application modules for settings page -->
-    <link rel="modulepreload" href="js/settings.js">
-    <link rel="modulepreload" href="js/yjs.js">
-    <link rel="modulepreload" href="js/settings-views.js">
-    <link rel="modulepreload" href="js/utils.js">
-    <link rel="modulepreload" href="js/navigation-cache.js">
-    <link rel="modulepreload" href="js/components/modal.js">
-    
-    <!-- Secondary modules -->
-    <link rel="modulepreload" href="js/ai.js">
-    <link rel="modulepreload" href="js/summarization.js">
-    <link rel="modulepreload" href="js/version.js">
-    
-    <!-- YJS and lib0 dependencies from node_modules -->
-    <link rel="modulepreload" href="./node_modules/yjs/dist/yjs.mjs">
-    <link rel="modulepreload" href="./node_modules/y-websocket/src/y-websocket.js">
-    <link rel="modulepreload" href="./node_modules/y-indexeddb/src/y-indexeddb.js">
-    <link rel="modulepreload" href="./node_modules/y-protocols/sync.js">
-    <link rel="modulepreload" href="./node_modules/y-protocols/awareness.js">
-    <link rel="modulepreload" href="./node_modules/lib0/observable.js">
-    <link rel="modulepreload" href="./node_modules/lib0/array.js">
-    <link rel="modulepreload" href="./node_modules/lib0/map.js">
-    <link rel="modulepreload" href="./node_modules/lib0/encoding.js">
-    <link rel="modulepreload" href="./node_modules/lib0/decoding.js">
-    <link rel="modulepreload" href="./node_modules/lib0/random.js">
-    <link rel="modulepreload" href="./node_modules/lib0/environment.js">
-    <link rel="modulepreload" href="./node_modules/lib0/indexeddb.js">
-    <link rel="modulepreload" href="./node_modules/lib0/broadcastchannel.js">
-    
     <!-- Import Map for YJS modules -->
     <script type="importmap">
     {
@@ -92,6 +62,38 @@
       }
     }
     </script>
+    
+    <!-- Module Preloads for Performance -->
+    <!-- Core application modules for settings page -->
+    <link rel="modulepreload" href="js/settings.js">
+    <link rel="modulepreload" href="js/yjs.js">
+    <link rel="modulepreload" href="js/settings-views.js">
+    <link rel="modulepreload" href="js/utils.js">
+    <link rel="modulepreload" href="js/navigation-cache.js">
+    <link rel="modulepreload" href="js/components/modal.js">
+    
+    <!-- Secondary modules -->
+    <link rel="modulepreload" href="js/ai.js">
+    <link rel="modulepreload" href="js/summarization.js">
+    <link rel="modulepreload" href="js/version.js">
+    
+    <!-- YJS and lib0 dependencies from node_modules -->
+    <link rel="modulepreload" href="./node_modules/yjs/dist/yjs.mjs">
+    <link rel="modulepreload" href="./node_modules/y-websocket/src/y-websocket.js">
+    <link rel="modulepreload" href="./node_modules/y-indexeddb/src/y-indexeddb.js">
+    <link rel="modulepreload" href="./node_modules/y-protocols/sync.js">
+    <link rel="modulepreload" href="./node_modules/y-protocols/awareness.js">
+    <link rel="modulepreload" href="./node_modules/lib0/observable.js">
+    <link rel="modulepreload" href="./node_modules/lib0/array.js">
+    <link rel="modulepreload" href="./node_modules/lib0/map.js">
+    <link rel="modulepreload" href="./node_modules/lib0/encoding.js">
+    <link rel="modulepreload" href="./node_modules/lib0/decoding.js">
+    <link rel="modulepreload" href="./node_modules/lib0/random.js">
+    <link rel="modulepreload" href="./node_modules/lib0/environment.js">
+    <link rel="modulepreload" href="./node_modules/lib0/indexeddb.js">
+    <link rel="modulepreload" href="./node_modules/lib0/broadcastchannel.js">
+    
+    
 
 </head>
 <body>


### PR DESCRIPTION
Move import map definition before module preloads and scripts to fix intermittent module resolution errors on navigation.

Browsers need the import map to be defined and parsed before encountering any module scripts or module preloads that use bare module specifiers (e.g., "yjs"). When navigating client-side, if the import map isn't processed early enough, subsequent module imports can fail to resolve, leading to the reported `TypeError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-754e2846-571f-49c9-9d8c-d2a36e157faa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-754e2846-571f-49c9-9d8c-d2a36e157faa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

