### PR TITLE
Fix undefined getStoredSummary reference error

### DIFF
--- a/js/journal-views.js
+++ b/js/journal-views.js
@@ -503,7 +503,7 @@ export const renderEntries = (container, entries, options = {}) => {
 // Ensure meta summary is available and render it into the provided element
 const ensureAndRenderMetaSummary = (allEntries, targetElement) => {
   const state = getYjsState();
-  const existing = getStoredSummary(state, 'journal:adventure-summary');
+  const existing = getSummary(state, 'journal:adventure-summary');
   if (existing) {
     targetElement.innerHTML = parseMarkdown(existing);
     return;


### PR DESCRIPTION
Replace undefined `getStoredSummary` with `getSummary` to fix a `ReferenceError` when rendering the journal page.

---
<a href="https://cursor.com/background-agent?bcId=bc-56911715-009f-4162-91b5-7f2286134596">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56911715-009f-4162-91b5-7f2286134596">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

