### PR TITLE
Prevent timestamp update on journal edit

### DIFF
--- a/js/yjs.js
+++ b/js/yjs.js
@@ -203,7 +203,9 @@ export const updateEntry = (state, entryId, updates) => {
   const entries = getEntries(state);
   const index = entries.findIndex(e => e.id === entryId);
   if (index !== -1) {
-    const updatedEntry = { ...entries[index], ...updates, timestamp: Date.now() };
+    // Preserve the original timestamp when editing an entry
+    const originalTimestamp = entries[index].timestamp;
+    const updatedEntry = { ...entries[index], ...updates, timestamp: originalTimestamp };
     getJournalArray(state).delete(index, 1);
     getJournalArray(state).insert(index, [updatedEntry]);
   }


### PR DESCRIPTION
Preserve the original timestamp when updating a journal entry.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bad28af-9bad-4e04-a18c-03d8a3f06c69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bad28af-9bad-4e04-a18c-03d8a3f06c69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

