### PR TITLE
Fix and test Ai prompt button

### DIFF
--- a/js/settings-views.js
+++ b/js/settings-views.js
@@ -170,6 +170,8 @@ export const renderAIPromptPreview = (...args) => {
     promptContentElement.innerHTML = header + content;
   }
   
+  // Ensure the preview is visible even if initially hidden via utility class
+  try { promptPreviewElement.classList.remove('is-hidden'); } catch {}
   promptPreviewElement.style.display = 'block';
 };
 

--- a/test/ui-settings.test.js
+++ b/test/ui-settings.test.js
@@ -104,6 +104,7 @@ describe('UI Contracts - Settings Page (settings.html)', function() {
     const preview = document.getElementById('ai-prompt-preview');
     const content = document.getElementById('ai-prompt-content');
     expect(preview.style.display).to.equal('block');
+    expect(preview.classList.contains('is-hidden')).to.equal(false);
     expect(content.innerHTML).to.satisfy((html) => html.includes('system-prompt') || html.includes('user-prompt'));
   });
 


### PR DESCRIPTION
Fix 'Show current AI prompt' button not displaying the prompt by removing the `is-hidden` class and add a regression test.

---
<a href="https://cursor.com/background-agent?bcId=bc-f43ce93a-93a6-4c2d-85b1-5850c088ecd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f43ce93a-93a6-4c2d-85b1-5850c088ecd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

